### PR TITLE
feat: event-driven SD free-space cache (alternative to polling)

### DIFF
--- a/lib/hal/HalStorage.cpp
+++ b/lib/hal/HalStorage.cpp
@@ -7,6 +7,15 @@
 #include <SdFat.h>
 
 #include <cassert>
+#include <ctime>
+
+static void sdFatDateTimeCallback(uint16_t* pdate, uint16_t* ptime) {
+  struct tm timeinfo;
+  const time_t t = time(nullptr);
+  localtime_r(&t, &timeinfo);
+  *pdate = FS_DATE(timeinfo.tm_year + 1900, timeinfo.tm_mon + 1, timeinfo.tm_mday);
+  *ptime = FS_TIME(timeinfo.tm_hour, timeinfo.tm_min, timeinfo.tm_sec);
+}
 
 #define SDCard SDCardManager::getInstance()
 
@@ -19,7 +28,19 @@ HalStorage::HalStorage() {
 
 // begin() and ready() are only called from setup, no need to acquire mutex for them
 
-bool HalStorage::begin() { return SDCard.begin(); }
+bool HalStorage::begin() {
+  FsDateTime::setCallback(sdFatDateTimeCallback);
+  const bool ok = SDCard.begin();
+  if (ok) {
+    // Pre-populate the total-bytes cache once (partition size never changes).
+    sdTotalBytesCache = SDCard.cardTotalBytes();
+    // Do an initial free-space walk synchronously — no other tasks are running yet during setup.
+    sdFreeMB = (uint32_t)(SDCard.cardFreeBytes() / 1000000ULL);
+    // Start the background refresh task.
+    xTaskCreate(sdFreeUpdateTask, "sdFree", 2048, this, 1, &sdFreeUpdateTaskHandle);
+  }
+  return ok;
+}
 
 bool HalStorage::ready() const { return SDCard.ready(); }
 
@@ -50,26 +71,45 @@ size_t HalStorage::readFileToBuffer(const char* path, char* buffer, size_t buffe
 }
 
 bool HalStorage::writeFile(const char* path, const String& content) {
-  HAL_STORAGE_WRAPPED_CALL(writeFile, path, content);
+  bool ok;
+  {
+    StorageLock lock;
+    ok = SDCard.writeFile(path, content);
+  }
+  if (ok) notifySdFreeUpdate();
+  return ok;
 }
 
 bool HalStorage::ensureDirectoryExists(const char* path) { HAL_STORAGE_WRAPPED_CALL(ensureDirectoryExists, path); }
 
-uint64_t HalStorage::sdTotalBytes() const {
-  StorageLock lock;
-  return SDCard.sdTotalBytes();
+uint64_t HalStorage::sdTotalBytes() const { return sdTotalBytesCache; }
+
+uint64_t HalStorage::sdFreeBytes() const {
+  // sdFreeMB is a volatile uint32_t written atomically on single-core RISC-V — no mutex needed.
+  return (uint64_t)sdFreeMB * 1000000ULL;
 }
 
 uint64_t HalStorage::sdUsedBytes() const {
-  StorageLock lock;
-  return SDCard.sdUsedBytes();
+  const uint64_t free = sdFreeBytes();
+  return sdTotalBytesCache > free ? sdTotalBytesCache - free : 0;
 }
 
-uint64_t HalStorage::sdFreeBytes() const {
-  uint64_t total = sdTotalBytes();
-  uint64_t used = sdUsedBytes();
-  if (total <= used) return 0;
-  return total - used;
+void HalStorage::notifySdFreeUpdate() {
+  if (sdFreeUpdateTaskHandle) xTaskNotifyGive(sdFreeUpdateTaskHandle);
+}
+
+// Background task: wakes on notification, then waits for a 5-second quiet window before
+// walking the FAT. This debounce ensures a batch of writes (e.g. 20 web uploads) triggers
+// exactly one FAT walk — at the end of the batch, not during it.
+void HalStorage::sdFreeUpdateTask(void* param) {
+  auto& self = *static_cast<HalStorage*>(param);
+  for (;;) {
+    ulTaskNotifyTake(pdTRUE, portMAX_DELAY);  // block until first notification
+    while (ulTaskNotifyTake(pdTRUE, pdMS_TO_TICKS(5000))) {
+    }  // reset window on each new notification
+    StorageLock lock;
+    self.sdFreeMB = (uint32_t)(SDCard.cardFreeBytes() / 1000000ULL);
+  }
 }
 
 class HalFile::Impl {
@@ -84,9 +124,20 @@ HalFile::HalFile(std::unique_ptr<Impl> impl) : impl(std::move(impl)) {}
 
 HalFile::~HalFile() = default;
 
-HalFile::HalFile(HalFile&&) = default;
+// Move constructor: transfer ownership and clear openedForWrite on the moved-from object
+// so a subsequent close() on it cannot trigger a spurious notify.
+HalFile::HalFile(HalFile&& other) noexcept : impl(std::move(other.impl)), openedForWrite(other.openedForWrite) {
+  other.openedForWrite = false;
+}
 
-HalFile& HalFile::operator=(HalFile&&) = default;
+HalFile& HalFile::operator=(HalFile&& other) noexcept {
+  if (this != &other) {
+    impl = std::move(other.impl);
+    openedForWrite = other.openedForWrite;
+    other.openedForWrite = false;
+  }
+  return *this;
+}
 
 HalFile HalStorage::open(const char* path, const oflag_t oflag) {
   StorageLock lock;  // ensure thread safety for the duration of this function
@@ -97,12 +148,29 @@ bool HalStorage::mkdir(const char* path, const bool pFlag) { HAL_STORAGE_WRAPPED
 
 bool HalStorage::exists(const char* path) { HAL_STORAGE_WRAPPED_CALL(exists, path); }
 
-bool HalStorage::remove(const char* path) { HAL_STORAGE_WRAPPED_CALL(remove, path); }
+bool HalStorage::remove(const char* path) {
+  bool ok;
+  {
+    StorageLock lock;
+    ok = SDCard.remove(path);
+  }
+  if (ok) notifySdFreeUpdate();
+  return ok;
+}
+
 bool HalStorage::rename(const char* oldPath, const char* newPath) {
   HAL_STORAGE_WRAPPED_CALL(rename, oldPath, newPath);
 }
 
-bool HalStorage::rmdir(const char* path) { HAL_STORAGE_WRAPPED_CALL(rmdir, path); }
+bool HalStorage::rmdir(const char* path) {
+  bool ok;
+  {
+    StorageLock lock;
+    ok = SDCard.rmdir(path);
+  }
+  if (ok) notifySdFreeUpdate();
+  return ok;
+}
 
 bool HalStorage::openFileForRead(const char* moduleName, const char* path, HalFile& file) {
   StorageLock lock;  // ensure thread safety for the duration of this function
@@ -125,6 +193,7 @@ bool HalStorage::openFileForWrite(const char* moduleName, const char* path, HalF
   FsFile fsFile;
   bool ok = SDCard.openFileForWrite(moduleName, path, fsFile);
   file = HalFile(std::make_unique<HalFile::Impl>(std::move(fsFile)));
+  if (ok) file.openedForWrite = true;
   return ok;
 }
 
@@ -136,7 +205,15 @@ bool HalStorage::openFileForWrite(const char* moduleName, const String& path, Ha
   return openFileForWrite(moduleName, path.c_str(), file);
 }
 
-bool HalStorage::removeDir(const char* path) { HAL_STORAGE_WRAPPED_CALL(removeDir, path); }
+bool HalStorage::removeDir(const char* path) {
+  bool ok;
+  {
+    StorageLock lock;
+    ok = SDCard.removeDir(path);
+  }
+  if (ok) notifySdFreeUpdate();
+  return ok;
+}
 
 // HalFile implementation
 // Allow doing file operations while ensuring thread safety via HalStorage's mutex.
@@ -167,7 +244,18 @@ size_t HalFile::write(uint8_t b) { HAL_FILE_WRAPPED_CALL(write, b); }
 bool HalFile::rename(const char* newPath) { HAL_FILE_WRAPPED_CALL(rename, newPath); }
 bool HalFile::isDirectory() const { HAL_FILE_FORWARD_CALL(isDirectory, ); }  // already thread-safe, no need to wrap
 void HalFile::rewindDirectory() { HAL_FILE_WRAPPED_CALL(rewindDirectory, ); }
-bool HalFile::close() { HAL_FILE_WRAPPED_CALL(close, ); }
+
+bool HalFile::close() {
+  HalStorage::StorageLock lock;
+  assert(impl != nullptr);
+  const bool ok = impl->file.close();
+  if (ok && openedForWrite) {
+    openedForWrite = false;  // clear before notify to prevent double-notify on double-close
+    HalStorage::getInstance().notifySdFreeUpdate();
+  }
+  return ok;
+}
+
 HalFile HalFile::openNextFile() {
   HalStorage::StorageLock lock;
   assert(impl != nullptr);

--- a/lib/hal/HalStorage.h
+++ b/lib/hal/HalStorage.h
@@ -3,6 +3,7 @@
 #include <Print.h>
 #include <common/FsApiConstants.h>  // for oflag_t
 #include <freertos/semphr.h>
+#include <freertos/task.h>
 
 #include <memory>
 #include <string>
@@ -45,8 +46,11 @@ class HalStorage {
   bool openFileForWrite(const char* moduleName, const String& path, HalFile& file);
   bool removeDir(const char* path);
 
+  // Returns total SD card size in bytes (cached — fast, no SD access).
   uint64_t sdTotalBytes() const;
+  // Returns used space in bytes (total minus free, both cached — fast).
   uint64_t sdUsedBytes() const;
+  // Returns free space in bytes (cached — fast, no SD access).
   uint64_t sdFreeBytes() const;
 
   static HalStorage& getInstance() { return instance; }
@@ -58,6 +62,20 @@ class HalStorage {
 
   bool initialized = false;
   SemaphoreHandle_t storageMutex = nullptr;
+
+  // Free-space cache. sdTotalBytes is populated once in begin() and never changes.
+  // sdFreeMB is a uint32_t written atomically on single-core RISC-V — no mutex needed for reads.
+  uint64_t sdTotalBytesCache = 0;
+  volatile uint32_t sdFreeMB = 0;
+
+  // Background task: blocks until notified, then waits for a 5-second quiet window
+  // (debounce) before walking the FAT to refresh sdFreeMB. This ensures that even a
+  // large batch of uploads or deletes triggers exactly one FAT walk, at the end.
+  static void sdFreeUpdateTask(void* param);
+  TaskHandle_t sdFreeUpdateTaskHandle = nullptr;
+
+  // Wake the background task. Safe to call from any task; no-op if the task was not started.
+  void notifySdFreeUpdate();
 };
 
 #define Storage HalStorage::getInstance()
@@ -66,13 +84,16 @@ class HalFile : public Print {
   friend class HalStorage;
   class Impl;
   std::unique_ptr<Impl> impl;
+  // Set by HalStorage::openFileForWrite; cleared after notifying sdFreeUpdateTask in close().
+  // Prevents read-only file closes from triggering unnecessary FAT walks.
+  bool openedForWrite = false;
   explicit HalFile(std::unique_ptr<Impl> impl);
 
  public:
   HalFile();
   ~HalFile();
-  HalFile(HalFile&&);
-  HalFile& operator=(HalFile&&);
+  HalFile(HalFile&&) noexcept;
+  HalFile& operator=(HalFile&&) noexcept;
   HalFile(const HalFile&) = delete;
   HalFile& operator=(const HalFile&) = delete;
 


### PR DESCRIPTION
## What this is

An alternative to PR #7 which replaces the blocking SD space calls with a 60-second polling background task.

This PR takes the same cached approach from PR #7 but replaces the periodic 60 s timer with an **event-driven** model: the FAT walk only happens when something actually changes the card contents, and only after a **5-second quiet window** (debounce) so a batch of uploads triggers exactly **one** walk — at the end of the batch.

## How it works

### Cached values (same as PR #7 — no SD access on read)
- `sdTotalBytesCache` — populated once in `begin()`, never changes (partition size is fixed)
- `sdFreeMB` — `volatile uint32_t`, written atomically; no mutex needed for reads on single-core RISC-V

### Background task (event-driven instead of polling)
```cpp
void HalStorage::sdFreeUpdateTask(void* param) {
  for (;;) {
    ulTaskNotifyTake(pdTRUE, portMAX_DELAY);           // sleep until first event
    while (ulTaskNotifyTake(pdTRUE, pdMS_TO_TICKS(5000))) {}  // reset window on each new event
    StorageLock lock;
    self.sdFreeMB = (uint32_t)(SDCard.cardFreeBytes() / 1000000ULL);
  }
}
```

### Who wakes the task
`notifySdFreeUpdate()` is called after:
- `writeFile()` — string write helper
- `remove()` / `rmdir()` / `removeDir()`
- `HalFile::close()` — **only** if the file was opened for write (guarded by `openedForWrite` flag)

### Batch-upload safety
A batch of 20 OPDS/web uploads → 20 `close()` calls → 20 `xTaskNotifyGive` calls → the 5 s debounce timer resets each time → **one** FAT walk, 5 s after the last file.

### `openedForWrite` flag (HalFile)
Prevents read-only `close()` calls from waking the task unnecessarily. The flag is transferred (and cleared on the source) during move construction/assignment so a moved-from `HalFile` can never trigger a spurious notify.

## Comparison with PR #7

| | PR #7 (polling) | This PR (event-driven) |
|---|---|---|
| FAT walk trigger | Timer, every 60 s | Write/delete events only |
| Batch behaviour | Up to 60 s stale | Single walk after 5 s quiet window |
| CPU when idle | Wakes every 60 s | Sleeps indefinitely |
| Read-only opens | Wakes task on close | No wakeup |
| FAT timestamps | Not set | `FsDateTime::setCallback` added |

## Hot-swap limitation

If the user removes the SD card, adds files on a PC, and re-inserts it while the device is running, the `sdFreeMB` cache will remain stale until the next write/delete on the device. PR #7's 60 s timer would self-correct within a minute in this case.

However, `SDCardManager` has no hot-plug detection (no card-detect pin or interrupt), so SdFat itself loses the card state on removal — the file browser would stop working too. The expected user flow is to power off, swap the card, and power back on, which calls `begin()` and re-populates both caches fresh. This makes the hot-swap stale-cache scenario a non-issue in practice.

The public API (`sdTotalBytes()`, `sdFreeBytes()`, `sdUsedBytes()`) is unchanged.