### PR TITLE
feat: Short press will go back to origin / long press will go back to home

### DIFF
--- a/src/activities/Activity.cpp
+++ b/src/activities/Activity.cpp
@@ -12,7 +12,7 @@ void Activity::requestUpdateAndWait() { activityManager.requestUpdateAndWait(); 
 
 void Activity::onGoHome() { activityManager.goHome(); }
 
-void Activity::onSelectBook(const std::string& path) { activityManager.goToReader(path); }
+void Activity::onSelectBook(const std::string& path) { activityManager.pushReader(path); }
 
 void Activity::startActivityForResult(std::unique_ptr<Activity>&& activity, ActivityResultHandler resultHandler) {
   this->resultHandler = std::move(resultHandler);

--- a/src/activities/ActivityManager.cpp
+++ b/src/activities/ActivityManager.cpp
@@ -200,6 +200,10 @@ void ActivityManager::goToReader(std::string path) {
   replaceActivity(std::make_unique<ReaderActivity>(renderer, mappedInput, std::move(path)));
 }
 
+void ActivityManager::pushReader(std::string path) {
+  pushActivity(std::make_unique<ReaderActivity>(renderer, mappedInput, std::move(path)));
+}
+
 void ActivityManager::goToSleep() {
   replaceActivity(std::make_unique<SleepActivity>(renderer, mappedInput));
   loop();  // Important: sleep screen must be rendered immediately, the caller will go to sleep right after this returns

--- a/src/activities/ActivityManager.h
+++ b/src/activities/ActivityManager.h
@@ -83,6 +83,7 @@ class ActivityManager {
   void goToRecentBooks();
   void goToBrowser();
   void goToReader(std::string path);
+  void pushReader(std::string path);
   void goToSleep();
   void goToBoot();
   void goToFullScreenMessage(std::string message, EpdFontFamily::Style style = EpdFontFamily::REGULAR);

--- a/src/activities/home/HomeActivity.cpp
+++ b/src/activities/home/HomeActivity.cpp
@@ -261,7 +261,7 @@ void HomeActivity::render(RenderLock&&) {
   }
 }
 
-void HomeActivity::onSelectBook(const std::string& path) { activityManager.goToReader(path); }
+void HomeActivity::onSelectBook(const std::string& path) { activityManager.pushReader(path); }
 
 void HomeActivity::onFileBrowserOpen() { activityManager.goToFileBrowser(); }
 

--- a/src/activities/reader/EpubReaderActivity.cpp
+++ b/src/activities/reader/EpubReaderActivity.cpp
@@ -183,20 +183,20 @@ void EpubReaderActivity::loop() {
         });
   }
 
-  // Long press BACK (1s+) goes to file selection
+  // Long press BACK (1s+) goes to home screen
   if (mappedInput.isPressed(MappedInputManager::Button::Back) && mappedInput.getHeldTime() >= ReaderUtils::GO_HOME_MS) {
-    activityManager.goToFileBrowser(epub ? epub->getPath() : "");
+    onGoHome();
     return;
   }
 
-  // Short press BACK goes directly to home (or restores position if viewing footnote)
+  // Short press BACK returns to the calling activity (or restores position if viewing footnote)
   if (mappedInput.wasReleased(MappedInputManager::Button::Back) &&
       mappedInput.getHeldTime() < ReaderUtils::GO_HOME_MS) {
     if (footnoteDepth > 0) {
       restoreSavedPosition();
       return;
     }
-    onGoHome();
+    finish();
     return;
   }
 
@@ -205,10 +205,10 @@ void EpubReaderActivity::loop() {
     return;
   }
 
-  // At end of the book, forward button goes home and back button returns to last page
+  // At end of the book, forward button returns to caller and back button returns to last page
   if (currentSpineIndex > 0 && currentSpineIndex >= epub->getSpineItemsCount()) {
     if (nextTriggered) {
-      onGoHome();
+      finish();
     } else {
       currentSpineIndex = epub->getSpineItemsCount() - 1;
       nextPageNumber = UINT16_MAX;

--- a/src/activities/reader/ReaderActivity.cpp
+++ b/src/activities/reader/ReaderActivity.cpp
@@ -88,23 +88,27 @@ void ReaderActivity::goToLibrary(const std::string& fromBookPath) {
 void ReaderActivity::onGoToEpubReader(std::unique_ptr<Epub> epub) {
   const auto epubPath = epub->getPath();
   currentBookPath = epubPath;
-  activityManager.replaceActivity(std::make_unique<EpubReaderActivity>(renderer, mappedInput, std::move(epub)));
+  startActivityForResult(std::make_unique<EpubReaderActivity>(renderer, mappedInput, std::move(epub)),
+                         [this](const ActivityResult&) { finish(); });
 }
 
 void ReaderActivity::onGoToBmpViewer(const std::string& path) {
-  activityManager.replaceActivity(std::make_unique<BmpViewerActivity>(renderer, mappedInput, path));
+  startActivityForResult(std::make_unique<BmpViewerActivity>(renderer, mappedInput, path),
+                         [this](const ActivityResult&) { finish(); });
 }
 
 void ReaderActivity::onGoToXtcReader(std::unique_ptr<Xtc> xtc) {
   const auto xtcPath = xtc->getPath();
   currentBookPath = xtcPath;
-  activityManager.replaceActivity(std::make_unique<XtcReaderActivity>(renderer, mappedInput, std::move(xtc)));
+  startActivityForResult(std::make_unique<XtcReaderActivity>(renderer, mappedInput, std::move(xtc)),
+                         [this](const ActivityResult&) { finish(); });
 }
 
 void ReaderActivity::onGoToTxtReader(std::unique_ptr<Txt> txt) {
   const auto txtPath = txt->getPath();
   currentBookPath = txtPath;
-  activityManager.replaceActivity(std::make_unique<TxtReaderActivity>(renderer, mappedInput, std::move(txt)));
+  startActivityForResult(std::make_unique<TxtReaderActivity>(renderer, mappedInput, std::move(txt)),
+                         [this](const ActivityResult&) { finish(); });
 }
 
 void ReaderActivity::onEnter() {

--- a/src/activities/reader/TxtReaderActivity.cpp
+++ b/src/activities/reader/TxtReaderActivity.cpp
@@ -117,16 +117,16 @@ void TxtReaderActivity::onExit() {
 }
 
 void TxtReaderActivity::loop() {
-  // Long press BACK (1s+) goes to file selection
+  // Long press BACK (1s+) goes to home screen
   if (mappedInput.isPressed(MappedInputManager::Button::Back) && mappedInput.getHeldTime() >= ReaderUtils::GO_HOME_MS) {
-    activityManager.goToFileBrowser(txt ? txt->getPath() : "");
+    onGoHome();
     return;
   }
 
-  // Short press BACK goes directly to home
+  // Short press BACK returns to the calling activity
   if (mappedInput.wasReleased(MappedInputManager::Button::Back) &&
       mappedInput.getHeldTime() < ReaderUtils::GO_HOME_MS) {
-    onGoHome();
+    finish();
     return;
   }
 
@@ -143,7 +143,7 @@ void TxtReaderActivity::loop() {
       currentPage++;
       requestUpdate();
     } else {
-      onGoHome();
+      finish();
     }
   }
 }

--- a/src/activities/reader/XtcReaderActivity.cpp
+++ b/src/activities/reader/XtcReaderActivity.cpp
@@ -71,15 +71,15 @@ void XtcReaderActivity::loop() {
     }
   }
 
-  // Long press BACK (1s+) goes to file selection
+  // Long press BACK (1s+) goes to home screen
   if (mappedInput.isPressed(MappedInputManager::Button::Back) && mappedInput.getHeldTime() >= goHomeMs) {
-    activityManager.goToFileBrowser(xtc ? xtc->getPath() : "");
+    onGoHome();
     return;
   }
 
-  // Short press BACK goes directly to home
+  // Short press BACK returns to the calling activity
   if (mappedInput.wasReleased(MappedInputManager::Button::Back) && mappedInput.getHeldTime() < goHomeMs) {
-    onGoHome();
+    finish();
     return;
   }
 
@@ -101,10 +101,10 @@ void XtcReaderActivity::loop() {
     return;
   }
 
-  // At end of the book, forward button goes home and back button returns to last page
+  // At end of the book, forward button returns to caller and back button returns to last page
   if (currentPage >= xtc->getPageCount()) {
     if (nextTriggered) {
-      onGoHome();
+      finish();
     } else {
       currentPage = xtc->getPageCount() - 1;
       requestUpdate();


### PR DESCRIPTION
## Summary

* **What is the goal of this PR?** I found the logic strange, so I changed it to my preferences
* **What changes are included?**

## Additional Context

Navigation flow after changes:

| Path | Stack | Short press Back | Long press Back |
| -- | -- | -- | -- |
| Home → Reader | [Home] | → Home | → Home (replace) |
| FileBrowser → Reader | [FileBrowser] | → FileBrowser | → Home (replace) |
| RecentBooks → Reader | [RecentBooks] | → RecentBooks | → Home (replace) |
| Boot resume → Reader | [] (empty) | → Home (empty stack fallback) | → Home (replace) |

---

### AI Usage

While CrossPoint doesn't have restrictions on AI tools in contributing, please be transparent about their usage as it 
helps set the right context for reviewers.

Did you use AI tools to help write this code? _**< YES | PARTIALLY | NO >**_


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added stack-based navigation for reader activities, preserving navigation history.

* **Bug Fixes**
  * Fixed back-button behavior in readers to return to previous screen instead of always navigating home.
  * Improved navigation flow when opening books from home screen—now properly maintains activity stack.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->