### PR TITLE
feat: Make information overlay applicable for custom bitmaps too

### DIFF
--- a/src/activities/boot_sleep/SleepActivity.cpp
+++ b/src/activities/boot_sleep/SleepActivity.cpp
@@ -183,10 +183,9 @@ void SleepActivity::onEnter() {
 }
 
 void SleepActivity::renderCustomSleepScreen() const {
-  const BookOverlayInfo overlayInfo =
-      (SETTINGS.sleepCoverOverlay != 0 && APP_STATE.lastSleepFromReader && !APP_STATE.openEpubPath.empty())
-          ? getBookOverlayInfo(APP_STATE.openEpubPath)
-          : BookOverlayInfo{};
+  const BookOverlayInfo overlayInfo{};
+  const bool shouldLoadOverlayInfo =
+      SETTINGS.sleepCoverOverlay != 0 && APP_STATE.lastSleepFromReader && !APP_STATE.openEpubPath.empty();
 
   // Check if we have a /.sleep (preferred) or /sleep directory
   const char* sleepDir = nullptr;
@@ -248,7 +247,9 @@ void SleepActivity::renderCustomSleepScreen() const {
         delay(100);
         Bitmap bitmap(file, true);
         if (bitmap.parseHeaders() == BmpReaderError::Ok) {
-          renderBitmapSleepScreen(bitmap, overlayInfo);
+          const BookOverlayInfo resolvedOverlayInfo =
+              shouldLoadOverlayInfo ? getBookOverlayInfo(APP_STATE.openEpubPath) : overlayInfo;
+          renderBitmapSleepScreen(bitmap, resolvedOverlayInfo);
           file.close();
           dir.close();
           return;
@@ -266,7 +267,9 @@ void SleepActivity::renderCustomSleepScreen() const {
     Bitmap bitmap(file, true);
     if (bitmap.parseHeaders() == BmpReaderError::Ok) {
       LOG_DBG("SLP", "Loading: /sleep.bmp");
-      renderBitmapSleepScreen(bitmap, overlayInfo);
+      const BookOverlayInfo resolvedOverlayInfo =
+          shouldLoadOverlayInfo ? getBookOverlayInfo(APP_STATE.openEpubPath) : overlayInfo;
+      renderBitmapSleepScreen(bitmap, resolvedOverlayInfo);
       file.close();
       return;
     }


### PR DESCRIPTION
## Summary

* **What is the goal of this PR?** The info overlay does work now for custom images too
* **What changes are included?**

## Additional Context

* Add any other information that might be helpful for the reviewer (e.g., performance implications, potential risks, 
  specific areas to focus on).

---

### AI Usage

While CrossPoint doesn't have restrictions on AI tools in contributing, please be transparent about their usage as it 
helps set the right context for reviewers.

Did you use AI tools to help write this code? _**< YES | PARTIALLY | NO >**_


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Sleep screen now only displays the book overlay (title/author/progress) when the sleep cover overlay setting is enabled and a book is currently open; otherwise the plain sleep image is shown.
  * This behavior is applied consistently to both randomly selected sleep images and the default sleep image, preventing overlays from appearing when no book is available.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->