### PR TITLE
fix: Use evenly-spaced dithering thresholds for factory LUT (Patryk Radtke)

### DIFF
--- a/lib/GfxRenderer/BitmapHelpers.cpp
+++ b/lib/GfxRenderer/BitmapHelpers.cpp
@@ -52,14 +52,13 @@ int adjustPixel(int gray) {
 
   return gray;
 }
-// Simple quantization without dithering - divide into 4 levels
-// The thresholds are fine-tuned to the X4 display
+// Simple quantization without dithering — evenly-spaced midpoint thresholds for factory LUT
 uint8_t quantizeSimple(int gray) {
-  if (gray < 45) {
+  if (gray < 43) {
     return 0;
-  } else if (gray < 70) {
+  } else if (gray < 128) {
     return 1;
-  } else if (gray < 140) {
+  } else if (gray < 213) {
     return 2;
   } else {
     return 3;

--- a/lib/GfxRenderer/BitmapHelpers.h
+++ b/lib/GfxRenderer/BitmapHelpers.h
@@ -125,37 +125,21 @@ class AtkinsonDitherer {
     if (adjusted < 0) adjusted = 0;
     if (adjusted > 255) adjusted = 255;
 
-    // Quantize to 4 levels
+    // Quantize to 4 levels — evenly-spaced midpoint thresholds for factory LUT
     uint8_t quantized;
     int quantizedValue;
-    if (false) {  // original thresholds
-      if (adjusted < 43) {
-        quantized = 0;
-        quantizedValue = 0;
-      } else if (adjusted < 128) {
-        quantized = 1;
-        quantizedValue = 85;
-      } else if (adjusted < 213) {
-        quantized = 2;
-        quantizedValue = 170;
-      } else {
-        quantized = 3;
-        quantizedValue = 255;
-      }
-    } else {  // fine-tuned to X4 eink display
-      if (adjusted < 30) {
-        quantized = 0;
-        quantizedValue = 15;
-      } else if (adjusted < 50) {
-        quantized = 1;
-        quantizedValue = 30;
-      } else if (adjusted < 140) {
-        quantized = 2;
-        quantizedValue = 80;
-      } else {
-        quantized = 3;
-        quantizedValue = 210;
-      }
+    if (adjusted < 43) {
+      quantized = 0;
+      quantizedValue = 0;
+    } else if (adjusted < 128) {
+      quantized = 1;
+      quantizedValue = 85;
+    } else if (adjusted < 213) {
+      quantized = 2;
+      quantizedValue = 170;
+    } else {
+      quantized = 3;
+      quantizedValue = 255;
     }
 
     // Calculate error (only distribute 6/8 = 75%)
@@ -229,37 +213,21 @@ class FloydSteinbergDitherer {
     if (adjusted < 0) adjusted = 0;
     if (adjusted > 255) adjusted = 255;
 
-    // Quantize to 4 levels (0, 85, 170, 255)
+    // Quantize to 4 levels — evenly-spaced midpoint thresholds for factory LUT
     uint8_t quantized;
     int quantizedValue;
-    if (false) {  // original thresholds
-      if (adjusted < 43) {
-        quantized = 0;
-        quantizedValue = 0;
-      } else if (adjusted < 128) {
-        quantized = 1;
-        quantizedValue = 85;
-      } else if (adjusted < 213) {
-        quantized = 2;
-        quantizedValue = 170;
-      } else {
-        quantized = 3;
-        quantizedValue = 255;
-      }
-    } else {  // fine-tuned to X4 eink display
-      if (adjusted < 30) {
-        quantized = 0;
-        quantizedValue = 15;
-      } else if (adjusted < 50) {
-        quantized = 1;
-        quantizedValue = 30;
-      } else if (adjusted < 140) {
-        quantized = 2;
-        quantizedValue = 80;
-      } else {
-        quantized = 3;
-        quantizedValue = 210;
-      }
+    if (adjusted < 43) {
+      quantized = 0;
+      quantizedValue = 0;
+    } else if (adjusted < 128) {
+      quantized = 1;
+      quantizedValue = 85;
+    } else if (adjusted < 213) {
+      quantized = 2;
+      quantizedValue = 170;
+    } else {
+      quantized = 3;
+      quantizedValue = 255;
     }
 
     // Calculate error


### PR DESCRIPTION
## Summary

* **What is the goal of this PR?** Cherrypicking patryk Radtkes fix
* **What changes are included?**

## Additional Context

* Add any other information that might be helpful for the reviewer (e.g., performance implications, potential risks, 
  specific areas to focus on).

---

### AI Usage

While CrossPoint doesn't have restrictions on AI tools in contributing, please be transparent about their usage as it 
helps set the right context for reviewers.

Did you use AI tools to help write this code? _**< YES | PARTIALLY | NO >**_


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved bitmap quantization and dithering algorithms for more consistent grayscale-to-4-level image conversion. Updated threshold values and standardized the quantization approach across dithering methods to produce higher-quality output.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->