### PR TITLE
feat(opds): Allow selecting the download format

### DIFF
--- a/lib/OpdsParser/OpdsParser.cpp
+++ b/lib/OpdsParser/OpdsParser.cpp
@@ -1,8 +1,80 @@
 #include "OpdsParser.h"
 
+#include <FsHelpers.h>
 #include <Logging.h>
 
 #include <cstring>
+
+namespace {
+// Returns the length of href after trimming trailing slashes.
+size_t trimmedHrefLength(const char* href) {
+  size_t len = strlen(href);
+  while (len > 0 && href[len - 1] == '/') {
+    len--;
+  }
+  return len;
+}
+
+std::string_view trimmedHrefView(const char* href) { return std::string_view{href, trimmedHrefLength(href)}; }
+
+// Returns an OpdsAcquisitionLink if the type and href correspond to a supported
+// acquisition format, otherwise returns an empty OpdsAcquisitionLink.
+OpdsAcquisitionLink supportedAcquisitionLink(const char* type, const char* href) {
+  if (!type || !href || type[0] == '\0' || href[0] == '\0') {
+    return {};
+  }
+
+  // Some OPDS feeds append a trailing slash to format URLs like
+  // `/opds/book/123/kepub/`. Trim it so suffix checks work on the final segment.
+  const std::string_view trimmedHref = trimmedHrefView(href);
+
+  if (strcmp(type, "application/epub+zip") == 0) {
+    if (FsHelpers::checkFileExtension(trimmedHref, ".kepub.epub")) {
+      return {href, type, "kepub", ".kepub.epub"};
+    }
+
+    // Calibre-Web-Automated uses trailing path segments like `/kepub/` instead of
+    // filename extensions, so match `/kepub` after trimming trailing slashes.
+    if (FsHelpers::checkFileExtension(trimmedHref, ".kepub") || FsHelpers::checkFileExtension(trimmedHref, "/kepub")) {
+      // Save bare KePub downloads with an `.epub` suffix so the existing ePub
+      // reader can open them.
+      return {href, type, "kepub", ".kepub.epub"};
+    }
+    return {href, type, "epub", ".epub"};
+  }
+
+  if (strcmp(type, "text/plain") == 0) {
+    return {href, type, "txt", ".txt"};
+  }
+
+  if (strcmp(type, "text/markdown") == 0 || strcmp(type, "text/x-markdown") == 0) {
+    return {href, type, "md", ".md"};
+  }
+
+  if (FsHelpers::checkFileExtension(trimmedHref, ".xtc")) {
+    return {href, "application/vnd.xteink.xtc", "xtc", ".xtc"};
+  }
+
+  if (FsHelpers::checkFileExtension(trimmedHref, ".xth") || FsHelpers::checkFileExtension(trimmedHref, ".xtch")) {
+    return {href, "application/vnd.xteink.xtch", "xtch", ".xtch"};
+  }
+
+  return {};
+}
+
+// Determine if the given OpdsEntry's acquisition link href is already present,
+// to prevent duplicate download targets.
+bool hasEquivalentAcquisitionLink(const OpdsEntry& entry, const OpdsAcquisitionLink& candidate) {
+  const std::string_view normalizedCandidateHref = trimmedHrefView(candidate.href.c_str());
+  for (const auto& link : entry.acquisitionLinks) {
+    if (trimmedHrefView(link.href.c_str()) == normalizedCandidateHref) {
+      return true;
+    }
+  }
+
+  return false;
+}
+}  // namespace
 
 OpdsParser::OpdsParser() {
   parser = XML_ParserCreate(nullptr);
@@ -116,10 +188,18 @@ void XMLCALL OpdsParser::startElement(void* userData, const XML_Char* name, cons
       }
 
       if (self->inEntry) {
-        if (rel && type && strstr(rel, "opds-spec.org/acquisition") != nullptr &&
-            strcmp(type, "application/epub+zip") == 0) {
-          self->currentEntry.type = OpdsEntryType::BOOK;
-          self->currentEntry.href = href;
+        if (rel && strstr(rel, "opds-spec.org/acquisition") != nullptr) {
+          const auto acquisition = supportedAcquisitionLink(type, href);
+          if (!acquisition.formatKey.empty() && !hasEquivalentAcquisitionLink(self->currentEntry, acquisition)) {
+            self->currentEntry.type = OpdsEntryType::BOOK;
+            if (self->currentEntry.acquisitionLinks.empty()) {
+              self->currentEntry.href = href;
+            } else if (self->currentEntry.acquisitionLinks.size() == 1 &&
+                       self->currentEntry.acquisitionLinks.capacity() < 3) {
+              self->currentEntry.acquisitionLinks.reserve(3);
+            }
+            self->currentEntry.acquisitionLinks.push_back(acquisition);
+          }
         } else if (type && strstr(type, "application/atom+xml") != nullptr) {
           if (self->currentEntry.type != OpdsEntryType::BOOK) {
             self->currentEntry.type = OpdsEntryType::NAVIGATION;

--- a/lib/OpdsParser/OpdsParser.h
+++ b/lib/OpdsParser/OpdsParser.h
@@ -13,6 +13,13 @@ enum class OpdsEntryType {
   BOOK         // Downloadable book
 };
 
+struct OpdsAcquisitionLink {
+  std::string href;
+  std::string mimeType;
+  std::string formatKey;
+  std::string fileExtension;
+};
+
 /**
  * Represents an entry from an OPDS feed (either a navigation link or a book).
  */
@@ -22,6 +29,7 @@ struct OpdsEntry {
   std::string author;  // Only for books
   std::string href;    // Navigation URL or epub download URL
   std::string id;
+  std::vector<OpdsAcquisitionLink> acquisitionLinks;
 };
 
 // Legacy alias for backward compatibility

--- a/src/activities/browser/OpdsBookBrowserActivity.cpp
+++ b/src/activities/browser/OpdsBookBrowserActivity.cpp
@@ -7,6 +7,7 @@
 #include <Logging.h>
 #include <OpdsStream.h>
 #include <WiFi.h>
+#include <Xtc.h>
 #include <expat.h>
 
 #include <cctype>
@@ -15,6 +16,7 @@
 
 #include "CrossPointSettings.h"
 #include "MappedInputManager.h"
+#include "OpdsFormatLabel.h"
 #include "activities/network/WifiSelectionActivity.h"
 #include "activities/util/KeyboardEntryActivity.h"
 #include "components/UITheme.h"
@@ -25,7 +27,20 @@
 
 namespace {
 constexpr int PAGE_ITEMS = 23;
+constexpr int FORMAT_ITEM_HEIGHT = 30;
+constexpr int FORMAT_LIST_TOP_OFFSET = 20;
+constexpr int FORMAT_LIST_BOTTOM_PADDING = 20;
+
+int formatItemsPerPage(const Rect& contentRect) {
+  const int midY = contentRect.y + contentRect.height / 2;
+  const int listTop = midY + FORMAT_LIST_TOP_OFFSET;
+  const int listBottom = contentRect.y + contentRect.height - FORMAT_LIST_BOTTOM_PADDING;
+  const int rawAvailableHeight = listBottom - listTop;
+  const int availableHeight = rawAvailableHeight > FORMAT_ITEM_HEIGHT ? rawAvailableHeight : FORMAT_ITEM_HEIGHT;
+  const int itemsPerPage = availableHeight / FORMAT_ITEM_HEIGHT;
+  return itemsPerPage > 0 ? itemsPerPage : 1;
 }
+}  // namespace
 
 void OpdsBookBrowserActivity::onEnter() {
   Activity::onEnter();
@@ -36,6 +51,9 @@ void OpdsBookBrowserActivity::onEnter() {
   currentPath = "";  // Root path - user provides full URL in settings
   searchTemplate.clear();
   selectorIndex = 0;
+  selectedBookIndex = -1;
+  formatSelectorIndex = 0;
+  formatSelectionLabels.clear();
   consumeConfirm = false;
   consumeBack = false;
   errorMessage.clear();
@@ -52,6 +70,7 @@ void OpdsBookBrowserActivity::onExit() {
 
   entries.clear();
   navigationHistory.clear();
+  formatSelectionLabels.clear();
 }
 
 void OpdsBookBrowserActivity::loop() {
@@ -93,11 +112,51 @@ void OpdsBookBrowserActivity::loop() {
 
   if (state == BrowserState::DOWNLOADING) return;
 
+  if (state == BrowserState::FORMAT_SELECTION) {
+    if (selectedBookIndex < 0 || selectedBookIndex >= static_cast<int>(entries.size())) {
+      state = BrowserState::BROWSING;
+      requestUpdate();
+      return;
+    }
+
+    const auto& entry = entries[selectedBookIndex];
+    if (entry.acquisitionLinks.empty()) {
+      state = BrowserState::BROWSING;
+      selectedBookIndex = -1;
+      formatSelectionLabels.clear();
+      requestUpdate();
+      return;
+    }
+
+    if (mappedInput.wasReleased(MappedInputManager::Button::Back)) {
+      state = BrowserState::BROWSING;
+      selectedBookIndex = -1;
+      formatSelectionLabels.clear();
+      requestUpdate();
+      return;
+    }
+
+    if (mappedInput.wasReleased(MappedInputManager::Button::Confirm)) {
+      downloadBook(entry, entry.acquisitionLinks[formatSelectorIndex]);
+      return;
+    }
+
+    buttonNavigator.onNextRelease([this, &entry] {
+      formatSelectorIndex = ButtonNavigator::nextIndex(formatSelectorIndex, entry.acquisitionLinks.size());
+      requestUpdate();
+    });
+    buttonNavigator.onPreviousRelease([this, &entry] {
+      formatSelectorIndex = ButtonNavigator::previousIndex(formatSelectorIndex, entry.acquisitionLinks.size());
+      requestUpdate();
+    });
+    return;
+  }
+
   if (state == BrowserState::BROWSING) {
     if (mappedInput.wasReleased(MappedInputManager::Button::Confirm)) {
       if (!entries.empty()) {
         const auto& entry = entries[selectorIndex];
-        entry.type == OpdsEntryType::BOOK ? downloadBook(entry) : navigateToEntry(entry);
+        entry.type == OpdsEntryType::BOOK ? chooseBookFormat(entry) : navigateToEntry(entry);
       }
     } else if (mappedInput.wasReleased(MappedInputManager::Button::Back)) {
       navigateBack();
@@ -171,6 +230,34 @@ void OpdsBookBrowserActivity::render(RenderLock&&) {
       const int barY = midY + 20;
       GUI.drawProgressBar(renderer, Rect{barX, barY, barWidth, barHeight}, downloadProgress, downloadTotal);
     }
+    renderer.displayBuffer();
+    return;
+  }
+
+  if (state == BrowserState::FORMAT_SELECTION) {
+    const auto& entry = entries[selectedBookIndex];
+    auto title = renderer.truncatedText(UI_10_FONT_ID, entry.title.c_str(), contentRect.width - 40);
+    renderer.drawCenteredText(UI_10_FONT_ID, midY - 40, title.c_str(), true, EpdFontFamily::BOLD);
+    if (!entry.author.empty()) {
+      auto author = renderer.truncatedText(UI_10_FONT_ID, entry.author.c_str(), contentRect.width - 40);
+      renderer.drawCenteredText(UI_10_FONT_ID, midY - 10, author.c_str());
+    }
+
+    const int listTop = midY + 20;
+    const int itemsPerPage = formatItemsPerPage(contentRect);
+    const int pageStartIndex = formatSelectorIndex / itemsPerPage * itemsPerPage;
+    renderer.fillRect(contentRect.x, listTop + (formatSelectorIndex - pageStartIndex) * FORMAT_ITEM_HEIGHT - 2,
+                      contentRect.width - 1, FORMAT_ITEM_HEIGHT);
+    for (int i = pageStartIndex;
+         i < static_cast<int>(entry.acquisitionLinks.size()) && i < pageStartIndex + itemsPerPage; i++) {
+      const char* label = i < static_cast<int>(formatSelectionLabels.size()) ? formatSelectionLabels[i].c_str() : "";
+      auto item = renderer.truncatedText(UI_10_FONT_ID, label, contentRect.width - 40);
+      renderer.drawText(UI_10_FONT_ID, contentRect.x + 20, listTop + (i - pageStartIndex) * FORMAT_ITEM_HEIGHT,
+                        item.c_str(), i != formatSelectorIndex);
+    }
+
+    const auto labels = mappedInput.mapLabels(tr(STR_BACK), tr(STR_DOWNLOAD), tr(STR_DIR_UP), tr(STR_DIR_DOWN));
+    GUI.drawButtonHints(renderer, labels.btn1, labels.btn2, labels.btn3, labels.btn4);
     renderer.displayBuffer();
     return;
   }
@@ -292,17 +379,43 @@ void OpdsBookBrowserActivity::navigateBack() {
   }
 }
 
-void OpdsBookBrowserActivity::downloadBook(const OpdsEntry& book) {
+// Opens a screen to allow the user to choose which format they want to download
+// if multiple formats are available. If only one format is available, the
+// download is started immediately.
+void OpdsBookBrowserActivity::chooseBookFormat(const OpdsEntry& book) {
+  if (book.acquisitionLinks.empty()) {
+    state = BrowserState::ERROR;
+    errorMessage = tr(STR_DOWNLOAD_FAILED);
+    requestUpdate();
+    return;
+  }
+
+  if (book.acquisitionLinks.size() == 1) {
+    downloadBook(book, book.acquisitionLinks[0]);
+    return;
+  }
+
+  selectedBookIndex = selectorIndex;
+  formatSelectorIndex = 0;
+  formatSelectionLabels = buildOpdsFormatSelectionLabels(book.acquisitionLinks, SETTINGS.opdsServerUrl);
+  state = BrowserState::FORMAT_SELECTION;
+  requestUpdate();
+}
+
+// Downloads the selected book's acquisition link and saves it to the SD card.
+void OpdsBookBrowserActivity::downloadBook(const OpdsEntry& book, const OpdsAcquisitionLink& acquisition) {
   state = BrowserState::DOWNLOADING;
   statusMessage = book.title;
   downloadProgress = 0;
   downloadTotal = 0;
   requestUpdate(true);
 
-  std::string downloadUrl =
-      (book.href.rfind("http", 0) == 0) ? book.href : UrlUtils::buildUrl(SETTINGS.opdsServerUrl, book.href);
-  std::string filename =
-      "/" + StringUtils::sanitizeFilename(book.title + (book.author.empty() ? "" : " - " + book.author)) + ".epub";
+  std::string downloadUrl = (acquisition.href.rfind("http", 0) == 0)
+                                ? acquisition.href
+                                : UrlUtils::buildUrl(SETTINGS.opdsServerUrl, acquisition.href);
+  std::string filename = "/" +
+                         StringUtils::sanitizeFilename(book.title + (book.author.empty() ? "" : " - " + book.author)) +
+                         acquisition.fileExtension;
 
   LOG_DBG("OPDS", "Downloading: %s -> %s", downloadUrl.c_str(), filename.c_str());
 
@@ -330,10 +443,20 @@ void OpdsBookBrowserActivity::downloadBook(const OpdsEntry& book) {
 
     LOG_DBG("OPDS", "Download complete: %s", filename.c_str());
 
-    Epub(filename, "/.crosspoint").clearCache();
+    // Clear any existing cache for this book just in case it's a redownload of
+    // a previously opened book.
+    if (acquisition.mimeType == "application/epub+zip") {
+      Epub(filename, "/.crosspoint").clearCache();
+    } else if (acquisition.formatKey == "xtc" || acquisition.formatKey == "xtch") {
+      Xtc(filename, "/.crosspoint").clearCache();
+    }
+    selectedBookIndex = -1;
+    formatSelectionLabels.clear();
     state = BrowserState::BROWSING;
     requestUpdate();
   } else {
+    selectedBookIndex = -1;
+    formatSelectionLabels.clear();
     state = BrowserState::ERROR;
     errorMessage = tr(STR_DOWNLOAD_FAILED);
     requestUpdate();

--- a/src/activities/browser/OpdsBookBrowserActivity.h
+++ b/src/activities/browser/OpdsBookBrowserActivity.h
@@ -1,7 +1,6 @@
 #pragma once
 #include <OpdsParser.h>
 
-#include <functional>
 #include <string>
 #include <vector>
 
@@ -14,7 +13,16 @@
  */
 class OpdsBookBrowserActivity final : public Activity {
  public:
-  enum class BrowserState { CHECK_WIFI, WIFI_SELECTION, LOADING, BROWSING, DOWNLOADING, ERROR, SEARCH_INPUT };
+  enum class BrowserState {
+    CHECK_WIFI,
+    WIFI_SELECTION,
+    LOADING,
+    BROWSING,
+    FORMAT_SELECTION,
+    DOWNLOADING,
+    ERROR,
+    SEARCH_INPUT
+  };
 
   explicit OpdsBookBrowserActivity(GfxRenderer& renderer, MappedInputManager& mappedInput)
       : Activity("OpdsBookBrowser", renderer, mappedInput), buttonNavigator() {}
@@ -34,6 +42,9 @@ class OpdsBookBrowserActivity final : public Activity {
   bool consumeConfirm = false;
   bool consumeBack = false;  // Added missing member
   int selectorIndex = 0;
+  int selectedBookIndex = -1;
+  int formatSelectorIndex = 0;
+  std::vector<std::string> formatSelectionLabels;
   std::string errorMessage;
   std::string statusMessage;
   size_t downloadProgress = 0;
@@ -45,7 +56,8 @@ class OpdsBookBrowserActivity final : public Activity {
   void fetchFeed(const std::string& path);
   void navigateToEntry(const OpdsEntry& entry);
   void navigateBack();
-  void downloadBook(const OpdsEntry& book);
+  void downloadBook(const OpdsEntry& book, const OpdsAcquisitionLink& acquisition);
+  void chooseBookFormat(const OpdsEntry& book);
   void fetchOsdTemplate(const std::string& osdUrl);
   void launchSearch();
   void performSearch(const std::string& query);

--- a/src/activities/browser/OpdsFormatLabel.cpp
+++ b/src/activities/browser/OpdsFormatLabel.cpp
@@ -1,0 +1,122 @@
+#include "OpdsFormatLabel.h"
+
+#include <algorithm>
+#include <iterator>
+
+#include "util/UrlUtils.h"
+
+namespace {
+bool hasDuplicateFormatKey(const OpdsAcquisitionLink& acquisition,
+                           const std::vector<OpdsAcquisitionLink>& acquisitionLinks) {
+  size_t sameFormatCount = 0;
+  for (const auto& link : acquisitionLinks) {
+    if (link.formatKey == acquisition.formatKey) {
+      sameFormatCount++;
+      if (sameFormatCount > 1) {
+        return true;
+      }
+    }
+  }
+
+  return false;
+}
+
+std::string resolvedHostname(const OpdsAcquisitionLink& acquisition, const std::string& serverUrl) {
+  const std::string resolvedUrl =
+      acquisition.href.rfind("http", 0) == 0 ? acquisition.href : UrlUtils::buildUrl(serverUrl, acquisition.href);
+  return UrlUtils::extractHostname(resolvedUrl);
+}
+
+std::vector<std::string> resolvedHostnames(const std::vector<OpdsAcquisitionLink>& acquisitionLinks,
+                                           const std::string& serverUrl) {
+  std::vector<std::string> hostnames;
+  hostnames.reserve(acquisitionLinks.size());
+  std::transform(acquisitionLinks.begin(), acquisitionLinks.end(), std::back_inserter(hostnames),
+                 [&serverUrl](const OpdsAcquisitionLink& link) { return resolvedHostname(link, serverUrl); });
+  return hostnames;
+}
+
+std::string buildDuplicateAwareLabel(const OpdsAcquisitionLink& acquisition,
+                                     const std::vector<OpdsAcquisitionLink>& acquisitionLinks,
+                                     const std::vector<std::string>& hostnames, const size_t currentIndex) {
+  std::string label = opdsBaseFormatLabel(acquisition);
+  if (!hasDuplicateFormatKey(acquisition, acquisitionLinks)) {
+    return label;
+  }
+
+  const std::string& hostname = hostnames[currentIndex];
+  if (hostname.empty()) {
+    return label;
+  }
+
+  label.reserve(label.size() + hostname.size() + 8);
+  label += " - ";
+  label += hostname;
+
+  size_t duplicateCount = 0;
+  size_t duplicateIndex = 0;
+  for (size_t i = 0; i < acquisitionLinks.size(); i++) {
+    if (acquisitionLinks[i].formatKey == acquisition.formatKey && hostnames[i] == hostname) {
+      duplicateCount++;
+      if (i <= currentIndex) {
+        duplicateIndex++;
+      }
+    }
+  }
+
+  if (duplicateCount > 1) {
+    label += " (";
+    label += std::to_string(duplicateIndex);
+    label += ")";
+  }
+
+  return label;
+}
+}  // namespace
+
+const char* opdsBaseFormatLabel(const OpdsAcquisitionLink& acquisition) {
+  if (acquisition.formatKey == "kepub") {
+    return "KEPUB";
+  }
+  if (acquisition.formatKey == "epub") {
+    return "EPUB";
+  }
+  if (acquisition.formatKey == "txt") {
+    return "TXT";
+  }
+  if (acquisition.formatKey == "md") {
+    return "MD";
+  }
+  if (acquisition.formatKey == "xtc") {
+    return "XTC";
+  }
+  if (acquisition.formatKey == "xtch") {
+    return "XTCH";
+  }
+
+  return "";
+}
+
+std::string opdsFormatSelectionLabel(const OpdsAcquisitionLink& acquisition,
+                                     const std::vector<OpdsAcquisitionLink>& acquisitionLinks,
+                                     const std::string& serverUrl) {
+  const auto hostnames = resolvedHostnames(acquisitionLinks, serverUrl);
+  for (size_t i = 0; i < acquisitionLinks.size(); i++) {
+    if (acquisitionLinks[i].href == acquisition.href && acquisitionLinks[i].formatKey == acquisition.formatKey) {
+      return buildDuplicateAwareLabel(acquisition, acquisitionLinks, hostnames, i);
+    }
+  }
+
+  return opdsBaseFormatLabel(acquisition);
+}
+
+std::vector<std::string> buildOpdsFormatSelectionLabels(const std::vector<OpdsAcquisitionLink>& acquisitionLinks,
+                                                        const std::string& serverUrl) {
+  const auto hostnames = resolvedHostnames(acquisitionLinks, serverUrl);
+  std::vector<std::string> labels;
+  labels.reserve(acquisitionLinks.size());
+  for (size_t i = 0; i < acquisitionLinks.size(); i++) {
+    labels.push_back(buildDuplicateAwareLabel(acquisitionLinks[i], acquisitionLinks, hostnames, i));
+  }
+  return labels;
+}

--- a/src/activities/browser/OpdsFormatLabel.h
+++ b/src/activities/browser/OpdsFormatLabel.h
@@ -1,0 +1,13 @@
+#pragma once
+
+#include <OpdsParser.h>
+
+#include <string>
+#include <vector>
+
+const char* opdsBaseFormatLabel(const OpdsAcquisitionLink& acquisition);
+std::string opdsFormatSelectionLabel(const OpdsAcquisitionLink& acquisition,
+                                     const std::vector<OpdsAcquisitionLink>& acquisitionLinks,
+                                     const std::string& serverUrl);
+std::vector<std::string> buildOpdsFormatSelectionLabels(const std::vector<OpdsAcquisitionLink>& acquisitionLinks,
+                                                        const std::string& serverUrl);

--- a/src/util/UrlUtils.cpp
+++ b/src/util/UrlUtils.cpp
@@ -1,6 +1,178 @@
 #include "UrlUtils.h"
 
+#include <algorithm>
+#include <string_view>
+
 namespace UrlUtils {
+
+namespace {
+void popLastSegment(std::string& path) {
+  if (path.empty()) {
+    return;
+  }
+
+  size_t end = path.size();
+  if (end > 1 && path.back() == '/') {
+    end--;
+  }
+
+  while (end > 0 && path[end - 1] != '/') {
+    end--;
+  }
+
+  path.resize(end);
+}
+
+std::string normalizePath(const std::string_view path) {
+  if (path.empty()) {
+    return "/";
+  }
+
+  std::string normalized;
+  normalized.reserve(path.size());
+
+  size_t inputPos = 0;
+  while (inputPos < path.size()) {
+    if (path.compare(inputPos, 3, "../") == 0) {
+      inputPos += 3;
+      continue;
+    }
+    if (path.compare(inputPos, 2, "./") == 0) {
+      inputPos += 2;
+      continue;
+    }
+    if (path.compare(inputPos, 3, "/./") == 0) {
+      inputPos += 2;
+      continue;
+    }
+    if (path.compare(inputPos, 2, "/.") == 0 && inputPos + 2 == path.size()) {
+      if (normalized.empty()) {
+        normalized.push_back('/');
+      } else if (normalized.back() != '/') {
+        normalized.push_back('/');
+      }
+      break;
+    }
+    if (path.compare(inputPos, 4, "/../") == 0) {
+      inputPos += 4;
+      popLastSegment(normalized);
+      if (normalized.empty() || normalized.back() != '/') {
+        normalized.push_back('/');
+      }
+      continue;
+    }
+    if (path.compare(inputPos, 3, "/..") == 0 && inputPos + 3 == path.size()) {
+      popLastSegment(normalized);
+      if (normalized.empty() || normalized.back() != '/') {
+        normalized.push_back('/');
+      }
+      break;
+    }
+    if (path.compare(inputPos, 1, ".") == 0 && inputPos + 1 == path.size()) {
+      break;
+    }
+    if (path.compare(inputPos, 2, "..") == 0 && inputPos + 2 == path.size()) {
+      break;
+    }
+
+    const size_t nextSlash = path[inputPos] == '/' ? path.find('/', inputPos + 1) : path.find('/', inputPos);
+    if (nextSlash == std::string::npos) {
+      normalized.append(path, inputPos, path.size() - inputPos);
+      break;
+    }
+
+    normalized.append(path, inputPos, nextSlash - inputPos);
+    inputPos = nextSlash;
+  }
+
+  if (path.front() == '/' && normalized.empty()) {
+    return "/";
+  }
+
+  if (path.front() == '/' && normalized.size() == 1) {
+    return normalized;
+  }
+
+  if (path.front() != '/' && normalized.empty()) {
+    return ".";
+  }
+
+  return normalized;
+}
+
+std::string_view stripQueryAndFragment(const std::string_view urlPath) {
+  const size_t suffixStart = urlPath.find_first_of("?#");
+  return suffixStart == std::string::npos ? urlPath : urlPath.substr(0, suffixStart);
+}
+
+std::string_view stripFragment(const std::string_view urlPath) {
+  const size_t fragmentStart = urlPath.find('#');
+  return fragmentStart == std::string::npos ? urlPath : urlPath.substr(0, fragmentStart);
+}
+
+std::string_view extractScheme(const std::string_view url) {
+  const size_t protocolEnd = url.find("://");
+  return protocolEnd == std::string::npos ? "" : url.substr(0, protocolEnd);
+}
+
+struct UrlSuffixParts {
+  std::string_view path;
+  std::string_view query;
+  std::string_view fragment;
+};
+
+UrlSuffixParts splitReference(const std::string_view ref) {
+  UrlSuffixParts parts;
+  const size_t fragmentStart = ref.find('#');
+  const size_t queryStart = ref.find('?');
+  const size_t pathEnd = std::min(queryStart == std::string::npos ? ref.size() : queryStart,
+                                  fragmentStart == std::string::npos ? ref.size() : fragmentStart);
+
+  parts.path = ref.substr(0, pathEnd);
+  if (queryStart != std::string::npos && (fragmentStart == std::string::npos || queryStart < fragmentStart)) {
+    const size_t queryEnd = fragmentStart == std::string::npos ? ref.size() : fragmentStart;
+    parts.query = ref.substr(queryStart, queryEnd - queryStart);
+  }
+  if (fragmentStart != std::string::npos) {
+    parts.fragment = ref.substr(fragmentStart);
+  }
+
+  return parts;
+}
+
+std::string_view extractHostView(const std::string_view url) {
+  const size_t protocolEnd = url.find("://");
+  if (protocolEnd == std::string::npos) {
+    const size_t authorityEnd = url.find_first_of("/?#");
+    return authorityEnd == std::string::npos ? url : url.substr(0, authorityEnd);
+  }
+
+  const size_t authorityStart = protocolEnd + 3;
+  const size_t authorityEnd = url.find_first_of("/?#", authorityStart);
+  return authorityEnd == std::string::npos ? url : url.substr(0, authorityEnd);
+}
+
+void appendView(std::string& out, const std::string_view view) { out.append(view.data(), view.size()); }
+
+std::string buildResolvedUrl(const std::string_view host, const std::string_view path, const std::string_view query,
+                             const std::string_view fragment) {
+  std::string resolved;
+  resolved.reserve(host.size() + path.size() + query.size() + fragment.size());
+  appendView(resolved, host);
+  appendView(resolved, path);
+  appendView(resolved, query);
+  appendView(resolved, fragment);
+  return resolved;
+}
+
+std::string normalizeJoinedPath(const std::string_view baseDir, const std::string_view relativePath) {
+  std::string combined;
+  combined.reserve(baseDir.size() + relativePath.size());
+  appendView(combined, baseDir);
+  appendView(combined, relativePath);
+  return normalizePath(combined);
+}
+}  // namespace
 
 bool isHttpsUrl(const std::string& url) { return url.rfind("https://", 0) == 0; }
 
@@ -11,17 +183,60 @@ std::string ensureProtocol(const std::string& url) {
   return url;
 }
 
-std::string extractHost(const std::string& url) {
-  const size_t protocolEnd = url.find("://");
-  if (protocolEnd == std::string::npos) {
-    // No protocol, find first slash
-    const size_t firstSlash = url.find('/');
-    return firstSlash == std::string::npos ? url : url.substr(0, firstSlash);
+std::string extractHost(const std::string& url) { return std::string(extractHostView(url)); }
+
+std::string extractHostname(const std::string& url) {
+  const std::string_view urlView(url);
+  const size_t protocolEnd = urlView.find("://");
+  size_t hostStart = protocolEnd == std::string::npos ? 0 : protocolEnd + 3;
+  if (hostStart >= urlView.size()) {
+    return "";
   }
-  // Find the first slash after the protocol
-  const size_t hostStart = protocolEnd + 3;
-  const size_t pathStart = url.find('/', hostStart);
-  return pathStart == std::string::npos ? url : url.substr(0, pathStart);
+
+  const size_t authorityEnd = urlView.find_first_of("/?#", hostStart);
+  const size_t authorityLimit = authorityEnd == std::string::npos ? urlView.size() : authorityEnd;
+  if (hostStart >= authorityLimit) {
+    return "";
+  }
+
+  if (protocolEnd == std::string::npos && urlView[hostStart] != '[') {
+    const size_t colonPos = urlView.find(':', hostStart);
+    if (colonPos != std::string::npos && colonPos < authorityLimit) {
+      bool digitsOnlyPort = colonPos + 1 < authorityLimit;
+      for (size_t i = colonPos + 1; i < authorityLimit; i++) {
+        if (urlView[i] < '0' || urlView[i] > '9') {
+          digitsOnlyPort = false;
+          break;
+        }
+      }
+      if (!digitsOnlyPort) {
+        return "";
+      }
+    }
+  }
+
+  const size_t atPos = urlView.find('@', hostStart);
+  if (atPos != std::string::npos && atPos < authorityLimit) {
+    hostStart = atPos + 1;
+  }
+  if (hostStart >= authorityLimit) {
+    return "";
+  }
+
+  if (urlView[hostStart] == '[') {
+    const size_t closingBracket = urlView.find(']', hostStart + 1);
+    if (closingBracket == std::string::npos || closingBracket >= authorityLimit || closingBracket == hostStart + 1) {
+      return "";
+    }
+    if (closingBracket + 1 < authorityLimit && urlView[closingBracket + 1] != ':') {
+      return "";
+    }
+    return std::string(urlView.substr(hostStart + 1, closingBracket - hostStart - 1));
+  }
+
+  const size_t portPos = urlView.find(':', hostStart);
+  const size_t hostEnd = (portPos == std::string::npos || portPos >= authorityLimit) ? authorityLimit : portPos;
+  return hostEnd > hostStart ? std::string(urlView.substr(hostStart, hostEnd - hostStart)) : "";
 }
 
 std::string buildUrl(const std::string& serverUrl, const std::string& path) {
@@ -30,18 +245,56 @@ std::string buildUrl(const std::string& serverUrl, const std::string& path) {
     return path;
   }
   const std::string urlWithProtocol = ensureProtocol(serverUrl);
+  const std::string_view strippedUrl = stripQueryAndFragment(urlWithProtocol);
   if (path.empty()) {
     return urlWithProtocol;
   }
+  const UrlSuffixParts refParts = splitReference(path);
+  if (path.rfind("//", 0) == 0) {
+    std::string resolved;
+    const std::string_view scheme = extractScheme(urlWithProtocol);
+    resolved.reserve(scheme.size() + 1 + path.size());
+    appendView(resolved, scheme);
+    resolved.push_back(':');
+    resolved += path;
+    return resolved;
+  }
   if (path[0] == '/') {
     // Absolute path - use just the host
-    return extractHost(urlWithProtocol) + path;
+    const std::string_view host = extractHostView(strippedUrl);
+    const std::string normalizedPath = normalizePath(refParts.path);
+    return buildResolvedUrl(host, normalizedPath, refParts.query, refParts.fragment);
   }
-  // Relative path - append to server URL
-  if (urlWithProtocol.back() == '/') {
-    return urlWithProtocol + path;
+  if (path[0] == '?') {
+    std::string resolved;
+    resolved.reserve(strippedUrl.size() + path.size());
+    appendView(resolved, strippedUrl);
+    resolved += path;
+    return resolved;
   }
-  return urlWithProtocol + "/" + path;
+  if (path[0] == '#') {
+    const std::string_view baseWithoutFragment = stripFragment(urlWithProtocol);
+    std::string resolved;
+    resolved.reserve(baseWithoutFragment.size() + path.size());
+    appendView(resolved, baseWithoutFragment);
+    resolved += path;
+    return resolved;
+  }
+
+  const std::string_view baseHost = extractHostView(strippedUrl);
+  std::string_view basePath = strippedUrl.substr(baseHost.size());
+  if (basePath.empty()) {
+    basePath = std::string_view("/");
+  }
+
+  const size_t lastSlash = basePath.find_last_of('/');
+  const std::string_view baseDir =
+      basePath.back() == '/'
+          ? basePath
+          : (lastSlash == std::string::npos ? std::string_view("/") : basePath.substr(0, lastSlash + 1));
+  const std::string resolvedPath =
+      refParts.path.empty() ? std::string(baseDir) : normalizeJoinedPath(baseDir, refParts.path);
+  return buildResolvedUrl(baseHost, resolvedPath, refParts.query, refParts.fragment);
 }
 
 }  // namespace UrlUtils

--- a/src/util/UrlUtils.h
+++ b/src/util/UrlUtils.h
@@ -19,6 +19,13 @@ std::string ensureProtocol(const std::string& url);
 std::string extractHost(const std::string& url);
 
 /**
+ * Extract hostname only from a URL (e.g., "example.com" from
+ * "http://example.com:8080/path"). Returns an empty string if no hostname can
+ * be determined.
+ */
+std::string extractHostname(const std::string& url);
+
+/**
  * Build full URL from server URL and path.
  * If path starts with /, it's an absolute path from the host root.
  * Otherwise, it's relative to the server URL.

--- a/test/opds_format_label/OpdsFormatLabelTest.cpp
+++ b/test/opds_format_label/OpdsFormatLabelTest.cpp
@@ -1,0 +1,118 @@
+#include <cstdio>
+#include <string>
+#include <vector>
+
+#include "../../src/activities/browser/OpdsFormatLabel.h"
+
+static int testsPassed = 0;
+static int testsFailed = 0;
+
+#define ASSERT_TRUE(cond)                                                \
+  do {                                                                   \
+    if (!(cond)) {                                                       \
+      fprintf(stderr, "  FAIL: %s:%d: %s\n", __FILE__, __LINE__, #cond); \
+      testsFailed++;                                                     \
+      return;                                                            \
+    }                                                                    \
+  } while (0)
+
+#define ASSERT_EQ(a, b)                                                         \
+  do {                                                                          \
+    if ((a) != (b)) {                                                           \
+      fprintf(stderr, "  FAIL: %s:%d: %s != %s\n", __FILE__, __LINE__, #a, #b); \
+      testsFailed++;                                                            \
+      return;                                                                   \
+    }                                                                           \
+  } while (0)
+
+#define PASS() testsPassed++
+
+namespace {
+OpdsAcquisitionLink makeLink(const char* href, const char* formatKey) {
+  return OpdsAcquisitionLink{href, "application/epub+zip", formatKey, ".epub"};
+}
+}  // namespace
+
+void testUniqueFormatUsesBaseLabel() {
+  printf("testUniqueFormatUsesBaseLabel...\n");
+  const auto link = makeLink("/books/example.epub", "epub");
+  const std::vector<OpdsAcquisitionLink> links{link};
+
+  ASSERT_EQ(opdsFormatSelectionLabel(link, links, "catalog.example.com"), "EPUB");
+  PASS();
+}
+
+void testDuplicateAbsoluteUrlsIncludeHostname() {
+  printf("testDuplicateAbsoluteUrlsIncludeHostname...\n");
+  const auto primary = makeLink("https://mirror-a.example.com/books/example.epub", "epub");
+  const auto secondary = makeLink("https://mirror-b.example.com/books/example.epub", "epub");
+  const std::vector<OpdsAcquisitionLink> links{primary, secondary};
+
+  ASSERT_EQ(opdsFormatSelectionLabel(primary, links, "catalog.example.com"), "EPUB - mirror-a.example.com");
+  ASSERT_EQ(opdsFormatSelectionLabel(secondary, links, "catalog.example.com"), "EPUB - mirror-b.example.com");
+  PASS();
+}
+
+void testDuplicateRootRelativeUrlsUseServerHostname() {
+  printf("testDuplicateRootRelativeUrlsUseServerHostname...\n");
+  const auto primary = makeLink("/opds/download/1/epub", "epub");
+  const auto secondary = makeLink("/opds/download/2/epub", "epub");
+  const std::vector<OpdsAcquisitionLink> links{primary, secondary};
+
+  ASSERT_EQ(opdsFormatSelectionLabel(primary, links, "https://catalog.example.com/opds"),
+            "EPUB - catalog.example.com (1)");
+  ASSERT_EQ(opdsFormatSelectionLabel(secondary, links, "https://catalog.example.com/opds"),
+            "EPUB - catalog.example.com (2)");
+  PASS();
+}
+
+void testDuplicateRelativeUrlsUseServerHostname() {
+  printf("testDuplicateRelativeUrlsUseServerHostname...\n");
+  const auto primary = makeLink("download/1.epub", "epub");
+  const auto secondary = makeLink("download/2.epub", "epub");
+  const std::vector<OpdsAcquisitionLink> links{primary, secondary};
+
+  ASSERT_EQ(opdsFormatSelectionLabel(primary, links, "catalog.example.com/opds"), "EPUB - catalog.example.com (1)");
+  ASSERT_EQ(opdsFormatSelectionLabel(secondary, links, "catalog.example.com/opds"), "EPUB - catalog.example.com (2)");
+  PASS();
+}
+
+void testDuplicateAbsoluteUrlsSameHostnameIncludeNumbering() {
+  printf("testDuplicateAbsoluteUrlsSameHostnameIncludeNumbering...\n");
+  const auto primary = makeLink("https://mirror.example.com/books/example.epub", "epub");
+  const auto secondary = makeLink("https://mirror.example.com/books/example-copy.epub", "epub");
+  const std::vector<OpdsAcquisitionLink> links{primary, secondary};
+
+  ASSERT_EQ(opdsFormatSelectionLabel(primary, links, "catalog.example.com"), "EPUB - mirror.example.com (1)");
+  ASSERT_EQ(opdsFormatSelectionLabel(secondary, links, "catalog.example.com"), "EPUB - mirror.example.com (2)");
+  PASS();
+}
+
+void testBatchLabelBuilderMatchesPerLinkLabels() {
+  printf("testBatchLabelBuilderMatchesPerLinkLabels...\n");
+  const auto first = makeLink("https://mirror.example.com/books/example.epub", "epub");
+  const auto second = makeLink("https://mirror.example.com/books/example-copy.epub", "epub");
+  const auto third = makeLink("/books/example.txt", "txt");
+  const std::vector<OpdsAcquisitionLink> links{first, second, third};
+
+  const auto labels = buildOpdsFormatSelectionLabels(links, "https://catalog.example.com/opds");
+  ASSERT_EQ(labels.size(), static_cast<size_t>(3));
+  ASSERT_EQ(labels[0], opdsFormatSelectionLabel(first, links, "https://catalog.example.com/opds"));
+  ASSERT_EQ(labels[1], opdsFormatSelectionLabel(second, links, "https://catalog.example.com/opds"));
+  ASSERT_EQ(labels[2], opdsFormatSelectionLabel(third, links, "https://catalog.example.com/opds"));
+  PASS();
+}
+
+int main() {
+  printf("=== OPDS Format Label Tests ===\n\n");
+
+  testUniqueFormatUsesBaseLabel();
+  testDuplicateAbsoluteUrlsIncludeHostname();
+  testDuplicateRootRelativeUrlsUseServerHostname();
+  testDuplicateRelativeUrlsUseServerHostname();
+  testDuplicateAbsoluteUrlsSameHostnameIncludeNumbering();
+  testBatchLabelBuilderMatchesPerLinkLabels();
+
+  printf("\n=== Results: %d passed, %d failed ===\n", testsPassed, testsFailed);
+  return testsFailed > 0 ? 1 : 0;
+}

--- a/test/opds_parser/OpdsParserTest.cpp
+++ b/test/opds_parser/OpdsParserTest.cpp
@@ -1,0 +1,333 @@
+#include <OpdsParser.h>
+
+#include <cstdint>
+#include <cstdio>
+#include <cstring>
+#include <string>
+
+static int testsPassed = 0;
+static int testsFailed = 0;
+
+#define ASSERT_TRUE(cond)                                                \
+  do {                                                                   \
+    if (!(cond)) {                                                       \
+      fprintf(stderr, "  FAIL: %s:%d: %s\n", __FILE__, __LINE__, #cond); \
+      testsFailed++;                                                     \
+      return;                                                            \
+    }                                                                    \
+  } while (0)
+
+#define ASSERT_EQ(a, b)                                                         \
+  do {                                                                          \
+    if ((a) != (b)) {                                                           \
+      fprintf(stderr, "  FAIL: %s:%d: %s != %s\n", __FILE__, __LINE__, #a, #b); \
+      testsFailed++;                                                            \
+      return;                                                                   \
+    }                                                                           \
+  } while (0)
+
+#define ASSERT_SIZE(a, b)                                                                                         \
+  do {                                                                                                            \
+    if ((a) != (b)) {                                                                                             \
+      fprintf(stderr, "  FAIL: %s:%d: %s == %zu, expected %zu\n", __FILE__, __LINE__, #a, static_cast<size_t>(a), \
+              static_cast<size_t>(b));                                                                            \
+      testsFailed++;                                                                                              \
+      return;                                                                                                     \
+    }                                                                                                             \
+  } while (0)
+
+#define PASS() testsPassed++
+
+namespace {
+bool parseSingleBookEntry(OpdsEntry& entryOut, const char* href, const char* type = "application/epub+zip") {
+  const std::string xml = std::string(R"(<?xml version="1.0" encoding="utf-8"?>
+<feed xmlns="http://www.w3.org/2005/Atom">
+  <entry>
+    <title>Example Book</title>
+    <author><name>Example Author</name></author>
+    <id>book-1</id>
+    <link rel="http://opds-spec.org/acquisition" type=")") +
+                          type + R"(" href=")" + href + R"("/>
+  </entry>
+</feed>)";
+
+  OpdsParser parser;
+  parser.write(reinterpret_cast<const uint8_t*>(xml.data()), xml.size());
+  parser.flush();
+
+  if (parser.error()) {
+    fprintf(stderr, "  FAIL: %s:%d: parser.error()\n", __FILE__, __LINE__);
+    testsFailed++;
+    return false;
+  }
+  const auto& entries = parser.getEntries();
+  if (entries.size() != 1) {
+    fprintf(stderr, "  FAIL: %s:%d: entries.size() == %zu, expected 1\n", __FILE__, __LINE__, entries.size());
+    testsFailed++;
+    return false;
+  }
+  entryOut = entries.front();
+  return true;
+}
+
+bool assertSingleFormat(const OpdsEntry& entry, const char* formatKey, const char* fileExtension) {
+  if (entry.type != OpdsEntryType::BOOK) {
+    fprintf(stderr, "  FAIL: %s:%d: entry.type != OpdsEntryType::BOOK\n", __FILE__, __LINE__);
+    testsFailed++;
+    return false;
+  }
+  if (entry.acquisitionLinks.size() != 1) {
+    fprintf(stderr, "  FAIL: %s:%d: entry.acquisitionLinks.size() == %zu, expected 1\n", __FILE__, __LINE__,
+            entry.acquisitionLinks.size());
+    testsFailed++;
+    return false;
+  }
+  if (entry.acquisitionLinks[0].formatKey != formatKey) {
+    fprintf(stderr, "  FAIL: %s:%d: formatKey actual='%s' expected='%s'\n", __FILE__, __LINE__,
+            entry.acquisitionLinks[0].formatKey.c_str(), formatKey);
+    testsFailed++;
+    return false;
+  }
+  if (entry.acquisitionLinks[0].fileExtension != fileExtension) {
+    fprintf(stderr, "  FAIL: %s:%d: fileExtension actual='%s' expected='%s'\n", __FILE__, __LINE__,
+            entry.acquisitionLinks[0].fileExtension.c_str(), fileExtension);
+    testsFailed++;
+    return false;
+  }
+  return true;
+}
+}  // namespace
+
+void testEpubExtension() {
+  printf("testEpubExtension...\n");
+  OpdsEntry entry;
+  if (!parseSingleBookEntry(entry, "/books/example.epub")) return;
+  ASSERT_TRUE(assertSingleFormat(entry, "epub", ".epub"));
+  PASS();
+}
+
+void testKepubDoubleExtension() {
+  printf("testKepubDoubleExtension...\n");
+  OpdsEntry entry;
+  if (!parseSingleBookEntry(entry, "/books/example.kepub.epub")) return;
+  ASSERT_TRUE(assertSingleFormat(entry, "kepub", ".kepub.epub"));
+  PASS();
+}
+
+void testBareKepubExtension() {
+  printf("testBareKepubExtension...\n");
+  OpdsEntry entry;
+  if (!parseSingleBookEntry(entry, "/books/example.kepub")) return;
+  ASSERT_TRUE(assertSingleFormat(entry, "kepub", ".kepub.epub"));
+  PASS();
+}
+
+void testSlashTerminatedKepubPath() {
+  printf("testSlashTerminatedKepubPath...\n");
+  OpdsEntry entry;
+  if (!parseSingleBookEntry(entry, "/opds/download/6516/kepub/")) return;
+  ASSERT_TRUE(assertSingleFormat(entry, "kepub", ".kepub.epub"));
+  PASS();
+}
+
+void testSlashTerminatedEpubPath() {
+  printf("testSlashTerminatedEpubPath...\n");
+  OpdsEntry entry;
+  if (!parseSingleBookEntry(entry, "/opds/download/6516/epub/")) return;
+  ASSERT_TRUE(assertSingleFormat(entry, "epub", ".epub"));
+  PASS();
+}
+
+void testDistinctAcquisitionFormatsRemainSeparate() {
+  printf("testDistinctAcquisitionFormatsRemainSeparate...\n");
+  const char* xml = R"(<?xml version="1.0" encoding="utf-8"?>
+<feed xmlns="http://www.w3.org/2005/Atom">
+  <entry>
+    <title>Example Book</title>
+    <author><name>Example Author</name></author>
+    <id>book-2</id>
+    <link rel="http://opds-spec.org/acquisition" type="application/epub+zip" href="/books/example.epub"/>
+    <link rel="http://opds-spec.org/acquisition" type="application/epub+zip" href="/books/example.kepub.epub"/>
+    <link rel="http://opds-spec.org/acquisition" type="text/plain" href="/books/example.txt"/>
+    <link rel="http://opds-spec.org/acquisition" type="text/markdown" href="/books/example.md"/>
+  </entry>
+</feed>)";
+
+  OpdsParser parser;
+  parser.write(reinterpret_cast<const uint8_t*>(xml), strlen(xml));
+  parser.flush();
+
+  ASSERT_TRUE(!parser.error());
+  const auto& entries = parser.getEntries();
+  ASSERT_SIZE(entries.size(), 1);
+  const auto& links = entries.front().acquisitionLinks;
+  ASSERT_SIZE(links.size(), 4);
+  ASSERT_EQ(links[0].formatKey, "epub");
+  ASSERT_EQ(links[1].formatKey, "kepub");
+  ASSERT_EQ(links[2].formatKey, "txt");
+  ASSERT_EQ(links[3].formatKey, "md");
+  PASS();
+}
+
+void testUnsupportedMimeType() {
+  printf("testUnsupportedMimeType...\n");
+  const char* xml = R"(<?xml version="1.0" encoding="utf-8"?>
+<feed xmlns="http://www.w3.org/2005/Atom">
+  <entry>
+    <title>Example Book</title>
+    <author><name>Example Author</name></author>
+    <id>book-3</id>
+    <link rel="http://opds-spec.org/acquisition" type="application/x-mobipocket-ebook" href="/books/example.mobi"/>
+  </entry>
+</feed>)";
+
+  OpdsParser parser;
+  parser.write(reinterpret_cast<const uint8_t*>(xml), strlen(xml));
+  parser.flush();
+
+  ASSERT_TRUE(!parser.error());
+  ASSERT_SIZE(parser.getEntries().size(), 0);
+  PASS();
+}
+
+void testEmptyHrefOrType() {
+  printf("testEmptyHrefOrType...\n");
+  const char* xml = R"(<?xml version="1.0" encoding="utf-8"?>
+<feed xmlns="http://www.w3.org/2005/Atom">
+  <entry>
+    <title>Empty Href</title>
+    <author><name>Example Author</name></author>
+    <id>book-4</id>
+    <link rel="http://opds-spec.org/acquisition" type="application/epub+zip" href=""/>
+  </entry>
+  <entry>
+    <title>Empty Type</title>
+    <author><name>Example Author</name></author>
+    <id>book-5</id>
+    <link rel="http://opds-spec.org/acquisition" type="" href="/books/example.epub"/>
+  </entry>
+  <entry>
+    <title>Missing Href</title>
+    <author><name>Example Author</name></author>
+    <id>book-6</id>
+    <link rel="http://opds-spec.org/acquisition" type="application/epub+zip"/>
+  </entry>
+  <entry>
+    <title>Missing Type</title>
+    <author><name>Example Author</name></author>
+    <id>book-7</id>
+    <link rel="http://opds-spec.org/acquisition" href="/books/example.epub"/>
+  </entry>
+</feed>)";
+
+  OpdsParser parser;
+  parser.write(reinterpret_cast<const uint8_t*>(xml), strlen(xml));
+  parser.flush();
+
+  ASSERT_TRUE(!parser.error());
+  const auto& entries = parser.getEntries();
+  ASSERT_SIZE(entries.size(), 0);
+  PASS();
+}
+
+void testDuplicateAcquisitionLinks() {
+  printf("testDuplicateAcquisitionLinks...\n");
+  const char* xml = R"(<?xml version="1.0" encoding="utf-8"?>
+<feed xmlns="http://www.w3.org/2005/Atom">
+  <entry>
+    <title>Example Book</title>
+    <author><name>Example Author</name></author>
+    <id>book-8</id>
+    <link rel="http://opds-spec.org/acquisition" type="application/epub+zip" href="/books/example.epub"/>
+    <link rel="http://opds-spec.org/acquisition" type="application/epub+zip" href="/books/example-copy.epub"/>
+  </entry>
+</feed>)";
+
+  OpdsParser parser;
+  parser.write(reinterpret_cast<const uint8_t*>(xml), strlen(xml));
+  parser.flush();
+
+  ASSERT_TRUE(!parser.error());
+  const auto& entries = parser.getEntries();
+  ASSERT_SIZE(entries.size(), 1);
+  const auto& links = entries.front().acquisitionLinks;
+  ASSERT_SIZE(links.size(), 2);
+  ASSERT_EQ(links[0].formatKey, "epub");
+  ASSERT_EQ(links[0].href, "/books/example.epub");
+  ASSERT_EQ(links[1].formatKey, "epub");
+  ASSERT_EQ(links[1].href, "/books/example-copy.epub");
+  PASS();
+}
+
+void testIdenticalHrefAcquisitionLinksAreDeduplicated() {
+  printf("testIdenticalHrefAcquisitionLinksAreDeduplicated...\n");
+  const char* xml = R"(<?xml version="1.0" encoding="utf-8"?>
+<feed xmlns="http://www.w3.org/2005/Atom">
+  <entry>
+    <title>Example Book</title>
+    <author><name>Example Author</name></author>
+    <id>book-9</id>
+    <link rel="http://opds-spec.org/acquisition" type="application/epub+zip" href="/books/example.epub"/>
+    <link rel="http://opds-spec.org/acquisition" type="application/epub+zip" href="/books/example.epub"/>
+  </entry>
+</feed>)";
+
+  OpdsParser parser;
+  parser.write(reinterpret_cast<const uint8_t*>(xml), strlen(xml));
+  parser.flush();
+
+  ASSERT_TRUE(!parser.error());
+  const auto& entries = parser.getEntries();
+  ASSERT_SIZE(entries.size(), 1);
+  const auto& links = entries.front().acquisitionLinks;
+  ASSERT_SIZE(links.size(), 1);
+  ASSERT_EQ(links[0].formatKey, "epub");
+  ASSERT_EQ(links[0].href, "/books/example.epub");
+  PASS();
+}
+
+void testSlashVariantHrefAcquisitionLinksAreDeduplicated() {
+  printf("testSlashVariantHrefAcquisitionLinksAreDeduplicated...\n");
+  const char* xml = R"(<?xml version="1.0" encoding="utf-8"?>
+<feed xmlns="http://www.w3.org/2005/Atom">
+  <entry>
+    <title>Example Book</title>
+    <author><name>Example Author</name></author>
+    <id>book-10</id>
+    <link rel="http://opds-spec.org/acquisition" type="application/epub+zip" href="/books/example.epub"/>
+    <link rel="http://opds-spec.org/acquisition" type="application/epub+zip" href="/books/example.epub/"/>
+  </entry>
+</feed>)";
+
+  OpdsParser parser;
+  parser.write(reinterpret_cast<const uint8_t*>(xml), strlen(xml));
+  parser.flush();
+
+  ASSERT_TRUE(!parser.error());
+  const auto& entries = parser.getEntries();
+  ASSERT_SIZE(entries.size(), 1);
+  const auto& links = entries.front().acquisitionLinks;
+  ASSERT_SIZE(links.size(), 1);
+  ASSERT_EQ(links[0].formatKey, "epub");
+  ASSERT_EQ(links[0].href, "/books/example.epub");
+  PASS();
+}
+
+int main() {
+  printf("=== OPDS Parser Tests ===\n\n");
+
+  testEpubExtension();
+  testKepubDoubleExtension();
+  testBareKepubExtension();
+  testSlashTerminatedKepubPath();
+  testSlashTerminatedEpubPath();
+  testDistinctAcquisitionFormatsRemainSeparate();
+  testUnsupportedMimeType();
+  testEmptyHrefOrType();
+  testDuplicateAcquisitionLinks();
+  testIdenticalHrefAcquisitionLinksAreDeduplicated();
+  testSlashVariantHrefAcquisitionLinksAreDeduplicated();
+
+  printf("\n=== Results: %d passed, %d failed ===\n", testsPassed, testsFailed);
+  return testsFailed > 0 ? 1 : 0;
+}

--- a/test/run_opds_format_label_test.sh
+++ b/test/run_opds_format_label_test.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+BUILD_DIR="$ROOT_DIR/build/opds_format_label"
+BINARY="$BUILD_DIR/OpdsFormatLabelTest"
+PLATFORMIO_DIR="${PLATFORMIO_CORE_DIR:-$HOME/.platformio}"
+ARDUINO_FRAMEWORK_DIR="$PLATFORMIO_DIR/packages/framework-arduinoespressif32"
+
+mkdir -p "$BUILD_DIR"
+
+SOURCES=(
+  "$ROOT_DIR/test/opds_format_label/OpdsFormatLabelTest.cpp"
+  "$ROOT_DIR/src/activities/browser/OpdsFormatLabel.cpp"
+  "$ROOT_DIR/src/util/UrlUtils.cpp"
+)
+
+CXXFLAGS=(
+  -std=c++20
+  -O2
+  -Wall
+  -Wextra
+  -pedantic
+  -fno-exceptions
+  -DARDUINO_USB_MODE=1
+  -DARDUINO_USB_CDC_ON_BOOT=1
+  -DDESTRUCTOR_CLOSES_FILE=1
+  -I"$ROOT_DIR/test/shims"
+  -I"$ROOT_DIR"
+  -I"$ROOT_DIR/lib"
+  -I"$ROOT_DIR/lib/OpdsParser"
+  -I"$ROOT_DIR/src"
+  -I"$ARDUINO_FRAMEWORK_DIR/cores/esp32"
+  -I"$ARDUINO_FRAMEWORK_DIR/variants/esp32c3"
+)
+
+c++ "${CXXFLAGS[@]}" "${SOURCES[@]}" -o "$BINARY"
+
+"$BINARY" "$@"

--- a/test/run_opds_parser_test.sh
+++ b/test/run_opds_parser_test.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+BUILD_DIR="$ROOT_DIR/build/opds_parser"
+BINARY="$BUILD_DIR/OpdsParserTest"
+PLATFORMIO_DIR="${PLATFORMIO_CORE_DIR:-$HOME/.platformio}"
+ARDUINO_FRAMEWORK_DIR="$PLATFORMIO_DIR/packages/framework-arduinoespressif32"
+
+mkdir -p "$BUILD_DIR"
+
+SOURCES=(
+  "$ROOT_DIR/test/opds_parser/OpdsParserTest.cpp"
+  "$ROOT_DIR/lib/FsHelpers/FsHelpers.cpp"
+  "$ROOT_DIR/lib/OpdsParser/OpdsParser.cpp"
+)
+
+CXXFLAGS=(
+  -std=c++20
+  -O2
+  -Wall
+  -Wextra
+  -pedantic
+  -fno-exceptions
+  -DARDUINO_USB_MODE=1
+  -DARDUINO_USB_CDC_ON_BOOT=1
+  -DDESTRUCTOR_CLOSES_FILE=1
+  -DXML_GE=0
+  -DXML_CONTEXT_BYTES=1024
+  -DUSE_UTF8_LONG_NAMES=1
+  -I"$ROOT_DIR/test/shims"
+  -I"$ROOT_DIR"
+  -I"$ROOT_DIR/lib"
+  -I"$ROOT_DIR/lib/FsHelpers"
+  -I"$ROOT_DIR/lib/OpdsParser"
+  -I"$ROOT_DIR/lib/Logging"
+  -I"$ARDUINO_FRAMEWORK_DIR/cores/esp32"
+  -I"$ARDUINO_FRAMEWORK_DIR/variants/esp32c3"
+)
+
+c++ "${CXXFLAGS[@]}" "${SOURCES[@]}" -lexpat -o "$BINARY"
+
+"$BINARY" "$@"

--- a/test/run_url_utils_test.sh
+++ b/test/run_url_utils_test.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+BUILD_DIR="$ROOT_DIR/build/url_utils"
+BINARY="$BUILD_DIR/UrlUtilsTest"
+PLATFORMIO_DIR="${PLATFORMIO_CORE_DIR:-$HOME/.platformio}"
+ARDUINO_FRAMEWORK_DIR="$PLATFORMIO_DIR/packages/framework-arduinoespressif32"
+
+mkdir -p "$BUILD_DIR"
+
+SOURCES=(
+  "$ROOT_DIR/test/url_utils/UrlUtilsTest.cpp"
+  "$ROOT_DIR/src/util/UrlUtils.cpp"
+)
+
+CXXFLAGS=(
+  -std=c++20
+  -O2
+  -Wall
+  -Wextra
+  -pedantic
+  -fno-exceptions
+  -DARDUINO_USB_MODE=1
+  -DARDUINO_USB_CDC_ON_BOOT=1
+  -DDESTRUCTOR_CLOSES_FILE=1
+  -I"$ROOT_DIR/test/shims"
+  -I"$ROOT_DIR"
+  -I"$ROOT_DIR/src"
+  -I"$ARDUINO_FRAMEWORK_DIR/cores/esp32"
+  -I"$ARDUINO_FRAMEWORK_DIR/variants/esp32c3"
+)
+
+c++ "${CXXFLAGS[@]}" "${SOURCES[@]}" -o "$BINARY"
+
+"$BINARY" "$@"

--- a/test/shims/HardwareSerial.h
+++ b/test/shims/HardwareSerial.h
@@ -1,0 +1,15 @@
+#pragma once
+
+#include "Print.h"
+
+class HWCDC : public Print {
+ public:
+  void begin(unsigned long) {}
+  operator bool() const { return true; }
+
+  size_t write(uint8_t) override { return 1; }
+  size_t write(const uint8_t*, size_t size) override { return size; }
+  void flush() override {}
+};
+
+inline HWCDC Serial;

--- a/test/shims/Print.h
+++ b/test/shims/Print.h
@@ -1,0 +1,21 @@
+#pragma once
+
+#include <cstddef>
+#include <cstdint>
+
+class Print {
+ public:
+  virtual ~Print() = default;
+
+  virtual size_t write(uint8_t) = 0;
+
+  virtual size_t write(const uint8_t* buffer, size_t size) {
+    size_t written = 0;
+    for (size_t i = 0; i < size; i++) {
+      written += write(buffer[i]);
+    }
+    return written;
+  }
+
+  virtual void flush() {}
+};

--- a/test/url_utils/UrlUtilsTest.cpp
+++ b/test/url_utils/UrlUtilsTest.cpp
@@ -1,0 +1,149 @@
+#include <cstdio>
+#include <string>
+
+#include "../../src/util/UrlUtils.h"
+
+static int testsPassed = 0;
+static int testsFailed = 0;
+
+#define ASSERT_EQ(a, b)                                                         \
+  do {                                                                          \
+    if ((a) != (b)) {                                                           \
+      fprintf(stderr, "  FAIL: %s:%d: %s != %s\n", __FILE__, __LINE__, #a, #b); \
+      testsFailed++;                                                            \
+      return;                                                                   \
+    }                                                                           \
+  } while (0)
+
+#define PASS() testsPassed++
+
+void testAbsoluteUrlRemainsUnchanged() {
+  printf("testAbsoluteUrlRemainsUnchanged...\n");
+  ASSERT_EQ(
+      UrlUtils::buildUrl("https://catalog.example.com/opds/feed.xml", "https://example.com/books/download/test.epub"),
+      "https://example.com/books/download/test.epub");
+  ASSERT_EQ(UrlUtils::buildUrl("https://catalog.example.com/opds/feed.xml", "//cdn.example.com/books/test.epub"),
+            "https://cdn.example.com/books/test.epub");
+  PASS();
+}
+
+void testRootRelativeUrlUsesHostRoot() {
+  printf("testRootRelativeUrlUsesHostRoot...\n");
+  ASSERT_EQ(UrlUtils::buildUrl("https://catalog.example.com/opds/feed.xml", "/books/download/test.epub"),
+            "https://catalog.example.com/books/download/test.epub");
+  PASS();
+}
+
+void testRelativeUrlUsesFeedDirectory() {
+  printf("testRelativeUrlUsesFeedDirectory...\n");
+  ASSERT_EQ(UrlUtils::buildUrl("https://catalog.example.com/opds/feed.xml", "download/test.epub"),
+            "https://catalog.example.com/opds/download/test.epub");
+  ASSERT_EQ(UrlUtils::buildUrl("https://catalog.example.com/opds/sub", "download/test.epub"),
+            "https://catalog.example.com/opds/download/test.epub");
+  ASSERT_EQ(UrlUtils::buildUrl("https://catalog.example.com/opds/sub/", "download/test.epub"),
+            "https://catalog.example.com/opds/sub/download/test.epub");
+  ASSERT_EQ(UrlUtils::buildUrl("https://catalog.example.com/opds/feed.xml", "images//cover.jpg"),
+            "https://catalog.example.com/opds/images//cover.jpg");
+  ASSERT_EQ(UrlUtils::buildUrl("https://catalog.example.com/opds/feed.xml", "subdir/"),
+            "https://catalog.example.com/opds/subdir/");
+  PASS();
+}
+
+void testParentRelativeUrlResolvesCorrectly() {
+  printf("testParentRelativeUrlResolvesCorrectly...\n");
+  ASSERT_EQ(UrlUtils::buildUrl("https://catalog.example.com/opds/sub/feed.xml", "../download/test.epub"),
+            "https://catalog.example.com/opds/download/test.epub");
+  PASS();
+}
+
+void testUrlsWithQueryAndFragmentResolveCorrectly() {
+  printf("testUrlsWithQueryAndFragmentResolveCorrectly...\n");
+  ASSERT_EQ(UrlUtils::buildUrl("https://catalog.example.com/opds/sub?auth=1", "download/test.epub"),
+            "https://catalog.example.com/opds/download/test.epub");
+  ASSERT_EQ(UrlUtils::buildUrl("https://catalog.example.com/opds/sub/#section", "download/test.epub?format=epub#start"),
+            "https://catalog.example.com/opds/sub/download/test.epub?format=epub#start");
+  ASSERT_EQ(UrlUtils::buildUrl("https://catalog.example.com/opds/feed.xml?auth=1#top", "download/test.epub"),
+            "https://catalog.example.com/opds/download/test.epub");
+  ASSERT_EQ(UrlUtils::buildUrl("https://catalog.example.com/opds/feed.xml", "/books?id=/../cover"),
+            "https://catalog.example.com/books?id=/../cover");
+  ASSERT_EQ(
+      UrlUtils::buildUrl("https://catalog.example.com/opds/feed.xml", "download/test.epub?next=/../cover#frag/../x"),
+      "https://catalog.example.com/opds/download/test.epub?next=/../cover#frag/../x");
+  ASSERT_EQ(UrlUtils::buildUrl("https://catalog.example.com/opds/feed.xml", "download/test.epub#frag?x=1"),
+            "https://catalog.example.com/opds/download/test.epub#frag?x=1");
+  PASS();
+}
+
+void testRootRelativeUrlsWithQueryAndFragmentResolveCorrectly() {
+  printf("testRootRelativeUrlsWithQueryAndFragmentResolveCorrectly...\n");
+  ASSERT_EQ(
+      UrlUtils::buildUrl("https://catalog.example.com/opds/feed.xml?auth=1", "/books/download/test.epub?format=epub"),
+      "https://catalog.example.com/books/download/test.epub?format=epub");
+  ASSERT_EQ(UrlUtils::buildUrl("https://catalog.example.com/opds/sub/#section", "/books/download/test.epub#start"),
+            "https://catalog.example.com/books/download/test.epub#start");
+  ASSERT_EQ(UrlUtils::buildUrl("https://catalog.example.com/opds/sub?auth=1#top",
+                               "/books/download/test.epub?format=epub#start"),
+            "https://catalog.example.com/books/download/test.epub?format=epub#start");
+  PASS();
+}
+
+void testHostOnlyBaseUrlsWithQueryAndFragmentResolveCorrectly() {
+  printf("testHostOnlyBaseUrlsWithQueryAndFragmentResolveCorrectly...\n");
+  ASSERT_EQ(UrlUtils::buildUrl("https://catalog.example.com?auth=1", "download/test.epub"),
+            "https://catalog.example.com/download/test.epub");
+  ASSERT_EQ(UrlUtils::buildUrl("https://catalog.example.com#top", "/books/download/test.epub"),
+            "https://catalog.example.com/books/download/test.epub");
+  ASSERT_EQ(UrlUtils::buildUrl("https://catalog.example.com?auth=1", "?page=2"), "https://catalog.example.com?page=2");
+  ASSERT_EQ(UrlUtils::buildUrl("https://catalog.example.com#top", "#latest"), "https://catalog.example.com#latest");
+  PASS();
+}
+
+void testQueryAndFragmentReferencesAreRfcCompliant() {
+  printf("testQueryAndFragmentReferencesAreRfcCompliant...\n");
+  ASSERT_EQ(UrlUtils::buildUrl("https://catalog.example.com/opds/feed.xml?auth=1", "#top"),
+            "https://catalog.example.com/opds/feed.xml?auth=1#top");
+  ASSERT_EQ(UrlUtils::buildUrl("https://catalog.example.com/opds/feed.xml?auth=1#old", "?page=2"),
+            "https://catalog.example.com/opds/feed.xml?page=2");
+  ASSERT_EQ(UrlUtils::buildUrl("https://catalog.example.com?auth=1#old", "#latest"),
+            "https://catalog.example.com?auth=1#latest");
+  PASS();
+}
+
+void testExtractHostnameHandlesPortsAndIpv6() {
+  printf("testExtractHostnameHandlesPortsAndIpv6...\n");
+  ASSERT_EQ(UrlUtils::extractHostname("https://catalog.example.com:8080/path"), "catalog.example.com");
+  ASSERT_EQ(UrlUtils::extractHostname("catalog.example.com:8080/opds"), "catalog.example.com");
+  ASSERT_EQ(UrlUtils::extractHostname("https://user:pass@[2001:db8::1]:8080/path?x=1#frag"), "2001:db8::1");
+  ASSERT_EQ(UrlUtils::extractHostname("http://[fe80::1234]#top"), "fe80::1234");
+  PASS();
+}
+
+void testExtractHostnameRejectsMalformedInputs() {
+  printf("testExtractHostnameRejectsMalformedInputs...\n");
+  ASSERT_EQ(UrlUtils::extractHostname("https:///path"), "");
+  ASSERT_EQ(UrlUtils::extractHostname("http://[]"), "");
+  ASSERT_EQ(UrlUtils::extractHostname("http://@/x"), "");
+  ASSERT_EQ(UrlUtils::extractHostname("http://[::1"), "");
+  ASSERT_EQ(UrlUtils::extractHostname("http://[::1]x"), "");
+  ASSERT_EQ(UrlUtils::extractHostname("mailto:user@example.com"), "");
+  ASSERT_EQ(UrlUtils::extractHostname("urn:isbn:1234567890"), "");
+  PASS();
+}
+
+int main() {
+  printf("=== OPDS URL Utils Tests ===\n\n");
+
+  testAbsoluteUrlRemainsUnchanged();
+  testRootRelativeUrlUsesHostRoot();
+  testRelativeUrlUsesFeedDirectory();
+  testParentRelativeUrlResolvesCorrectly();
+  testUrlsWithQueryAndFragmentResolveCorrectly();
+  testRootRelativeUrlsWithQueryAndFragmentResolveCorrectly();
+  testHostOnlyBaseUrlsWithQueryAndFragmentResolveCorrectly();
+  testQueryAndFragmentReferencesAreRfcCompliant();
+  testExtractHostnameHandlesPortsAndIpv6();
+  testExtractHostnameRejectsMalformedInputs();
+
+  printf("\n=== Results: %d passed, %d failed ===\n", testsPassed, testsFailed);
+  return testsFailed > 0 ? 1 : 0;
+}


### PR DESCRIPTION
## Summary

* **What is the goal of this PR?** (e.g., Implements the new feature for file uploading.)
  * When downloading a book via OPDS, the last acquisition link is chosen when there are multiple. This PR allows choosing which format to download when there are many. Having only one format will automatically download that format.

* **What changes are included?**
  * `OpdsParser` is updated to gather the acquisition links for a title on the OPDS feed.
  * `OpdsBookBrowserActivity` is updated to display a list of formats the user can choose from.

## Additional Context

* The KePub format is a special case, it's just an ePub file with extra Kobo-specific markup and uses the same `application/epub+zip` MIME type. The double extension `.kepub.epub` is actually what the Kobo reader looks for to identify a file as KePub or ePub.
* There is a small risk here if people use KePub on one device and try to sync progress with another using an ePub version of the same book. The ePub location string can be used in the KePub no problem, but the KePub location string is invalid in the ePub.
  * This should only be an issue in the specific case where Calibre-Web-Automated is the kosync server, and that only after (if) a PR is merged to normalize the kosync progress record across formats. In all other cases (including CWA today, that PR isn't yet merged) the KePub and ePub will have different content hashes and also different file names and be seen as different books regardless of what matching method is used.
* This behavior is actually what prompted this PR, KOReader takes the first supported acquisition link but crosspoint takes the last. Really neither is guaranteed to be what the user intends, but taking the first one is typically going to be correct more often provided the links are sorted in alphabetical order of format.
* This shows as two commits temporarily because it's stacked with #99, once that PR is merged and I rebase this will go down to one commit.

---

### AI Usage

While CrossPoint doesn't have restrictions on AI tools in contributing, please be transparent about their usage as it 
helps set the right context for reviewers.

Did you use AI tools to help write this code? _**PARTIALLY**_, to help reason about correctness, reducing heap allocations, test cases, loop to `std::transform()`, `std::string_view()`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Choose preferred file format when downloading OPDS books with multiple formats
  * Entries now store multiple acquisition/download links; relative URLs are resolved correctly

* **UI**
  * New format-selection screen and flow when a book has multiple available formats; single-format books download immediately

* **Bug Fixes**
  * Improved detection/deduplication of acquisition links; ignores empty/missing hrefs/types and trailing slashes
  * Downloads use format-aware filenames and perform format-specific cache clearing

* **Tests**
  * Added parser tests, shims, and build/run script for validating format detection and URL resolution
<!-- end of auto-generated comment: release notes by coderabbit.ai -->