### PR TITLE
feat: Incorporate and fix upstream PR 1635

### DIFF
--- a/lib/hal/HalGPIO.h
+++ b/lib/hal/HalGPIO.h
@@ -38,6 +38,11 @@
 #define QMI8658_WHO_AM_I_REG 0x00    // WHO_AM_I command code
 #define QMI8658_WHO_AM_I_VALUE 0x05  // WHO_AM_I expected value
 
+namespace X3GPIO {
+// Read a 16-bit little-endian I2C register. Returns false on bus error.
+bool readI2CReg16LE(uint8_t addr, uint8_t reg, uint16_t* outValue);
+}  // namespace X3GPIO
+
 class HalGPIO {
 #if CROSSPOINT_EMULATED == 0
   InputManager inputMgr;

--- a/lib/hal/HalPowerManager.cpp
+++ b/lib/hal/HalPowerManager.cpp
@@ -36,9 +36,10 @@ void HalPowerManager::setPowerSaving(bool enabled) {
     enabled = false;
   }
 
-  // Note: We don't use mutex here to avoid too much overhead,
-  // it's not very important if we read a slightly stale value for currentLockMode
-  const LockMode mode = currentLockMode;
+  // Relaxed atomic read: a slightly stale value is acceptable (the lock holder
+  // that just won the race will re-call setPowerSaving anyway), but we want
+  // defined semantics rather than relying on compiler behavior for a plain int.
+  const LockMode mode = currentLockMode.load(std::memory_order_relaxed);
 
   if (mode == None && enabled && !isLowPower) {
     LOG_DBG("PWR", "Going to low-power mode");
@@ -101,45 +102,50 @@ void HalPowerManager::startDeepSleep(HalGPIO& gpio, bool keepClockAlive) const {
 }
 
 uint16_t HalPowerManager::getBatteryPercentage() const {
+  // Guard against an X3 board mistakenly taking the ADC path: BAT_GPIO0 is
+  // reused as X3_I2C_SCL on X3, so reading it as ADC would collide with the
+  // fuel-gauge bus. _batteryUseI2C must match the detected device type.
+  assert(_batteryUseI2C == gpio.deviceIsX3());
   if (_batteryUseI2C) {
     const unsigned long now = millis();
     if (_batteryLastPollMs != 0 && (now - _batteryLastPollMs) < BATTERY_POLL_MS) {
       return _batteryCachedPercent;
     }
 
-    // Read SOC directly from I2C fuel gauge (16-bit LE register).
+    // Read SOC from the I2C fuel gauge via the shared helper so the transaction
+    // shape stays consistent with other BQ27220/DS3231/QMI8658 reads.
     // On I2C error, keep last known value to avoid UI jitter/slowdowns.
-    Wire.beginTransmission(I2C_ADDR_BQ27220);
-    Wire.write(BQ27220_SOC_REG);
-    if (Wire.endTransmission(false) != 0) {
-      _batteryLastPollMs = now;
-      return _batteryCachedPercent;
+    uint16_t soc = 0;
+    if (X3GPIO::readI2CReg16LE(I2C_ADDR_BQ27220, BQ27220_SOC_REG, &soc)) {
+      _batteryCachedPercent = soc > 100 ? 100 : soc;
     }
-    Wire.requestFrom(I2C_ADDR_BQ27220, (uint8_t)2);
-    if (Wire.available() < 2) {
-      _batteryLastPollMs = now;
-      return _batteryCachedPercent;
-    }
-    const uint8_t lo = Wire.read();
-    const uint8_t hi = Wire.read();
-    const uint16_t soc = (hi << 8) | lo;
-    _batteryCachedPercent = soc > 100 ? 100 : soc;
     _batteryLastPollMs = now;
     return _batteryCachedPercent;
   }
   static const BatteryMonitor battery = BatteryMonitor(BAT_GPIO0);
-  _batteryCachedPercent = battery.readPercentage();
-  return _batteryCachedPercent;
+
+  // Smooth the battery % with a 1/10-weight IIR. The cache stores the value
+  // scaled ×10 so integer math keeps enough precision. Seed explicitly on the
+  // first real sample; using 0 as a sentinel caused a second seed whenever a
+  // later reading momentarily returned 0, producing visible jumps.
+  const uint16_t sample = battery.readPercentage();
+  if (!_batterySeeded) {
+    _batteryCachedPercent = 10 * sample;
+    _batterySeeded = true;
+  } else {
+    _batteryCachedPercent = (_batteryCachedPercent * 9 + sample * 10) / 10;
+  }
+  return _batteryCachedPercent / 10;
 }
 
 HalPowerManager::Lock::Lock() {
   xSemaphoreTake(powerManager.modeMutex, portMAX_DELAY);
   // Current limitation: only one lock at a time
-  if (powerManager.currentLockMode != None) {
+  if (powerManager.currentLockMode.load(std::memory_order_relaxed) != None) {
     LOG_ERR("PWR", "Lock already held, ignore");
     valid = false;
   } else {
-    powerManager.currentLockMode = NormalSpeed;
+    powerManager.currentLockMode.store(NormalSpeed, std::memory_order_relaxed);
     valid = true;
   }
   xSemaphoreGive(powerManager.modeMutex);
@@ -152,7 +158,7 @@ HalPowerManager::Lock::Lock() {
 HalPowerManager::Lock::~Lock() {
   xSemaphoreTake(powerManager.modeMutex, portMAX_DELAY);
   if (valid) {
-    powerManager.currentLockMode = None;
+    powerManager.currentLockMode.store(None, std::memory_order_relaxed);
   }
   xSemaphoreGive(powerManager.modeMutex);
 }

--- a/lib/hal/HalPowerManager.h
+++ b/lib/hal/HalPowerManager.h
@@ -7,6 +7,7 @@
 #include <Wire.h>
 #include <freertos/semphr.h>
 
+#include <atomic>
 #include <cassert>
 
 #include "HalGPIO.h"
@@ -20,12 +21,13 @@ class HalPowerManager {
 
   // I2C fuel gauge configuration for X3 battery monitoring
   bool _batteryUseI2C = false;                   // True if using I2C fuel gauge (X3), false for ADC (X4)
-  mutable int _batteryCachedPercent = 0;         // Last read battery percentage (0-100)
+  mutable int _batteryCachedPercent = 0;         // Last read battery percentage — X3: 0-100, X4: 0-1000 (scaled)
+  mutable bool _batterySeeded = false;           // True once the smoothing filter has a first real sample (X4)
   mutable unsigned long _batteryLastPollMs = 0;  // Timestamp of last battery read in milliseconds
 
   enum LockMode { None, NormalSpeed };
-  LockMode currentLockMode = None;
-  SemaphoreHandle_t modeMutex = nullptr;  // Protect access to currentLockMode
+  std::atomic<LockMode> currentLockMode{None};
+  SemaphoreHandle_t modeMutex = nullptr;  // Protect Lock acquire/release ordering
 
  public:
   static constexpr int LOW_POWER_FREQ = 10;                    // MHz


### PR DESCRIPTION
## Summary

* **What is the goal of this PR?** (e.g., Implements the new feature for file uploading.)
* **What changes are included?**

## Additional Context
Fix 1 — X3/X4 battery path mismatch guard HalPowerManager.cpp:107
Original impact: BAT_GPIO0 (GPIO0) on X3 hardware is wired as X3_I2C_SCL. If _batteryUseI2C ever got out of sync with the detected device (e.g. a future refactor calling getBatteryPercentage() before begin(), or the I2C flag being cleared), the ADC read would drive GPIO0 as an analog input while the fuel-gauge/RTC/IMU are still clocking it as SCL — corrupting every I2C transaction on the bus, not just the battery read.

Change: Added assert(_batteryUseI2C == gpio.deviceIsX3()) so any future drift trips immediately in debug builds instead of manifesting as mysterious sensor failures.

Fix 2 — Smoothing filter seed bug HalPowerManager.cpp:131-137 : 
Original impact: The old code used _batteryCachedPercent == 0 as "not yet seeded." Any subsequent battery.readPercentage() == 0 (low battery, transient ADC glitch, noise) would make the cached value decay to zero and re-trigger the seed branch — wiping the filter history and causing the displayed percentage to jump. On X4 hardware with a near-empty battery, the smoothing would effectively stop working.

Change: Added an explicit _batterySeeded bool. The filter seeds exactly once on the first sample and never again, so a transient 0 reading is treated as a normal low sample and smoothed.

Fix 3 — Lock-free currentLockMode race HalPowerManager.cpp:39-42 :
Original impact: setPowerSaving() read currentLockMode without the mutex (intentional, to keep the hot path cheap), but the field was a plain enum. With no volatile / std::atomic, the compiler was free to hoist the load out of a loop, cache it in a register, or tear reads relative to the Lock ctor/dtor writes. On ESP32-C3 (single-core RISC-V) tearing is unlikely for an int-sized enum, but the C++ memory model still makes this formally undefined behavior — an optimizer upgrade could start producing wrong CPU-frequency decisions.

Change: Promoted to std::atomic<LockMode> with memory_order_relaxed on all accesses. Same codegen on C3, now well-defined.

Fix 4 — I2C transaction duplication / inconsistency HalPowerManager.cpp:113-119 :
Original impact: The BQ27220 read in getBatteryPercentage() used its own hand-rolled Wire.beginTransmission/write/requestFrom sequence, while the probing code in HalGPIO.cpp:36 already had X3GPIO::readI2CReg16LE(). Two problems: (a) the local version didn't drain stale bytes on short reads (the helper does — important if a previous transaction left the receive FIFO non-empty), and (b) any future fix to I2C error handling (e.g. adding a bus mutex for cross-thread safety) had to be applied in two places.

Change: Exposed X3GPIO::readI2CReg16LE in HalGPIO.h and reused it here. Single code path for all BQ27220/DS3231/QMI8658 register reads.

---

### AI Usage

While CrossPoint doesn't have restrictions on AI tools in contributing, please be transparent about their usage as it 
helps set the right context for reviewers.

Did you use AI tools to help write this code? _**< YES | PARTIALLY | NO >**_


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added I2C register reading capability for enhanced hardware support.

* **Bug Fixes**
  * Improved battery percentage accuracy with enhanced filtering algorithm.
  * Strengthened I2C communication with better error handling and fallback recovery.
  * Added hardware validation to prevent incorrect battery reading configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->