### PR TITLE
fix(clangd): Remove gcc args not valid in clang

### DIFF
--- a/.clangd
+++ b/.clangd
@@ -1,2 +1,5 @@
 CompileFlags:
     Add: [-std=c++2a]
+    Remove:
+      - -fno-tree-switch-conversion
+      - -fstrict-volatile-bitfields


### PR DESCRIPTION
## Summary

* **What is the goal of this PR?** (e.g., Implements the new feature for file uploading.)
  * QoL update to remove spurious errors from clangd
* **What changes are included?**
  * `.clangd` has a `Remove` entry added to `CompileFlags`

## Additional Context

* After running `pio run --target compiledb` to generate `compile_commands.json`, clangd (at least in neovim) throws errors that `-fno-tree-switch-conversion` and `-fstrict-volatile-bitfields` are not valid flags.

---

### AI Usage

While CrossPoint doesn't have restrictions on AI tools in contributing, please be transparent about their usage as it 
helps set the right context for reviewers.

Did you use AI tools to help write this code? _**NO**_


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated development build configuration for improved compiler compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->