### PR TITLE
fix: harden OPDS parser cleanup after errors

### DIFF
--- a/lib/OpdsParser/OpdsParser.cpp
+++ b/lib/OpdsParser/OpdsParser.cpp
@@ -40,6 +40,7 @@ size_t OpdsParser::write(const uint8_t* xmlData, const size_t length) {
     if (!buf) {
       errorOccured = true;
       XML_ParserFree(parser);
+      parser = nullptr;
       return length;
     }
 
@@ -49,6 +50,7 @@ size_t OpdsParser::write(const uint8_t* xmlData, const size_t length) {
     if (XML_ParseBuffer(parser, static_cast<int>(toRead), 0) == XML_STATUS_ERROR) {
       errorOccured = true;
       XML_ParserFree(parser);
+      parser = nullptr;
       return length;
     }
     currentPos += toRead;
@@ -58,6 +60,10 @@ size_t OpdsParser::write(const uint8_t* xmlData, const size_t length) {
 }
 
 void OpdsParser::flush() {
+  if (!parser) {
+    errorOccured = true;
+    return;
+  }
   if (XML_Parse(parser, nullptr, 0, XML_TRUE) != XML_STATUS_OK) {
     errorOccured = true;
     XML_ParserFree(parser);


### PR DESCRIPTION
## Summary

* **What is the goal of this PR?** (e.g., Implements the new feature for file uploading.)
  * Fix potential use-after-free or double-free issue in the OPDS parser by nulling it after free and guarding against using a nullptr parser in `flush()`.
* **What changes are included?**
  * Nullify Expat parser after free and guard against freeing a null parser

## Additional Context

*

---

### AI Usage

While CrossPoint doesn't have restrictions on AI tools in contributing, please be transparent about their usage as it 
helps set the right context for reviewers.

Did you use AI tools to help write this code? _**PARTIALLY**_ - I asked for potential issues to investigate


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced error handling in XML feed parsing to prevent application crashes and improve overall stability when the parser encounters errors, invalid data, or unexpected failure conditions. Improved resource cleanup ensures more reliable and predictable behavior during feed processing, especially in challenging edge cases and error scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->