### PR TITLE
fix: free parser on error

### DIFF
--- a/lib/Epub/Epub/parsers/ContainerParser.cpp
+++ b/lib/Epub/Epub/parsers/ContainerParser.cpp
@@ -35,6 +35,8 @@ size_t ContainerParser::write(const uint8_t* buffer, const size_t size) {
     void* const buf = XML_GetBuffer(parser, 1024);
     if (!buf) {
       LOG_DBG("CTR", "Couldn't allocate buffer");
+      XML_ParserFree(parser);
+      parser = nullptr;
       return 0;
     }
 
@@ -43,6 +45,8 @@ size_t ContainerParser::write(const uint8_t* buffer, const size_t size) {
 
     if (XML_ParseBuffer(parser, static_cast<int>(toRead), remainingSize == toRead) == XML_STATUS_ERROR) {
       LOG_ERR("CTR", "Parse error: %s", XML_ErrorString(XML_GetErrorCode(parser)));
+      XML_ParserFree(parser);
+      parser = nullptr;
       return 0;
     }
 


### PR DESCRIPTION
## Summary

* **What is the goal of this PR?** (e.g., Implements the new feature for file uploading.)
  * Found while looking into #105 but the opposite problem. This frees the parser after an error has occurred and early return.
* **What changes are included?**
  * Free and null parser when returning early in `ContainerParser`

## Additional Context

* 

---

### AI Usage

While CrossPoint doesn't have restrictions on AI tools in contributing, please be transparent about their usage as it 
helps set the right context for reviewers.

Did you use AI tools to help write this code? _**NO**_
