### PR TITLE
fix: use same file name as KOReader for OPDS downloads

### DIFF
--- a/src/activities/browser/OpdsBookBrowserActivity.cpp
+++ b/src/activities/browser/OpdsBookBrowserActivity.cpp
@@ -415,7 +415,7 @@ void OpdsBookBrowserActivity::downloadBook(const OpdsEntry& book, const OpdsAcqu
                                 ? acquisition.href
                                 : UrlUtils::buildUrl(SETTINGS.opdsServerUrl, acquisition.href);
   std::string filename = "/" +
-                         StringUtils::sanitizeFilename(book.title + (book.author.empty() ? "" : " - " + book.author)) +
+                         StringUtils::sanitizeFilename((book.author.empty() ? "" : book.author + " - ") + book.title) +
                          acquisition.fileExtension;
 
   LOG_DBG("OPDS", "Downloading: %s -> %s", downloadUrl.c_str(), filename.c_str());


### PR DESCRIPTION
This re-instates the functionality of commit e5ab071, which was blown away by later changes.

## Summary

* **What is the goal of this PR?** Brings the names of files downloaded
via OPDS into line with the KOReader OPDS plugin so the files sync when
KOSync is set to filename matching

* **What changes are included?** Change the filename generated by the
OPDS browser from "\<title\> - \<author\>" to "\<author\> - \<title\>"
so it matches KOReader.

## Additional Context

* Add any other information that might be helpful for the reviewer (e.g., performance implications, potential risks, 
  specific areas to focus on).

---

### AI Usage

While CrossPoint doesn't have restrictions on AI tools in contributing, please be transparent about their usage as it 
helps set the right context for reviewers.

Did you use AI tools to help write this code? _**NO**_


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected the filename format for downloaded books to display author name first, followed by title, for improved file organization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->