### PR TITLE
fix: Use correct server name for opds download

### DIFF
--- a/src/SettingsList.h
+++ b/src/SettingsList.h
@@ -277,15 +277,6 @@ inline const std::vector<SettingInfo> list = {
     SettingInfo::Toggle(StrId::STR_KO_SYNC_ON_BOOK_CLOSE, &CrossPointSettings::koSyncOnBookClose, "koSyncOnBookClose",
                         StrId::STR_KOREADER_SYNC),
 
-    // --- OPDS Browser (web-only, uses CrossPointSettings char arrays) ---
-    SettingInfo::String(StrId::STR_OPDS_SERVER_URL, SETTINGS.opdsServerUrl, sizeof(SETTINGS.opdsServerUrl),
-                        "opdsServerUrl", StrId::STR_OPDS_BROWSER),
-    SettingInfo::String(StrId::STR_USERNAME, SETTINGS.opdsUsername, sizeof(SETTINGS.opdsUsername), "opdsUsername",
-                        StrId::STR_OPDS_BROWSER),
-    SettingInfo::String(StrId::STR_PASSWORD, SETTINGS.opdsPassword, sizeof(SETTINGS.opdsPassword), "opdsPassword",
-                        StrId::STR_OPDS_BROWSER)
-        .withObfuscated(),
-
     // --- Status Bar Settings (web-only, uses StatusBarSettingsActivity) ---
     SettingInfo::Toggle(StrId::STR_CHAPTER_PAGE_COUNT, &CrossPointSettings::statusBarChapterPageCount,
                         "statusBarChapterPageCount", StrId::STR_CUSTOMISE_STATUS_BAR),

--- a/src/activities/browser/OpdsBookBrowserActivity.cpp
+++ b/src/activities/browser/OpdsBookBrowserActivity.cpp
@@ -411,9 +411,8 @@ void OpdsBookBrowserActivity::downloadBook(const OpdsEntry& book, const OpdsAcqu
   downloadTotal = 0;
   requestUpdate(true);
 
-  std::string downloadUrl = (acquisition.href.rfind("http", 0) == 0)
-                                ? acquisition.href
-                                : UrlUtils::buildUrl(server.url, acquisition.href);
+  std::string downloadUrl =
+      (acquisition.href.rfind("http", 0) == 0) ? acquisition.href : UrlUtils::buildUrl(server.url, acquisition.href);
   std::string filename = "/" +
                          StringUtils::sanitizeFilename((book.author.empty() ? "" : book.author + " - ") + book.title) +
                          acquisition.fileExtension;

--- a/src/activities/browser/OpdsBookBrowserActivity.cpp
+++ b/src/activities/browser/OpdsBookBrowserActivity.cpp
@@ -398,7 +398,7 @@ void OpdsBookBrowserActivity::chooseBookFormat(const OpdsEntry& book) {
 
   selectedBookIndex = selectorIndex;
   formatSelectorIndex = 0;
-  formatSelectionLabels = buildOpdsFormatSelectionLabels(book.acquisitionLinks, SETTINGS.opdsServerUrl);
+  formatSelectionLabels = buildOpdsFormatSelectionLabels(book.acquisitionLinks, server.url);
   state = BrowserState::FORMAT_SELECTION;
   requestUpdate();
 }
@@ -413,7 +413,7 @@ void OpdsBookBrowserActivity::downloadBook(const OpdsEntry& book, const OpdsAcqu
 
   std::string downloadUrl = (acquisition.href.rfind("http", 0) == 0)
                                 ? acquisition.href
-                                : UrlUtils::buildUrl(SETTINGS.opdsServerUrl, acquisition.href);
+                                : UrlUtils::buildUrl(server.url, acquisition.href);
   std::string filename = "/" +
                          StringUtils::sanitizeFilename((book.author.empty() ? "" : book.author + " - ") + book.title) +
                          acquisition.fileExtension;


### PR DESCRIPTION
## Summary

* **What is the goal of this PR?** OPDS downloads were failing because the URL was constructed from the old SETTINGS.opdsServerUrl which is no longer used. This change uses the server name from the new json config to give the right URL. While we're about it also remove the old unused OPDS settings from the web page.

* **What changes are included?**
1) Replace SETTINGS.opdsServerUrl with server.url in 2 places in src\activities\browser\OpdsBookBrowserActivity.cpp
2) Remove lines related to the old OPDS settings from SettingsList.h so they're not displayed in the web page
## Additional Context

* Add any other information that might be helpful for the reviewer (e.g., performance implications, potential risks, 
  specific areas to focus on).
I haven't touched the settings from the data stored in flash as changing that format seems to have wider effects.

---

### AI Usage

While CrossPoint doesn't have restrictions on AI tools in contributing, please be transparent about their usage as it 
helps set the right context for reviewers.

Did you use AI tools to help write this code? _**< YES >**_


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Restructured OPDS server configuration management to use runtime-based settings instead of global shared settings storage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->